### PR TITLE
Fix crash on windows when camera is busy

### DIFF
--- a/src/rtc_video_device_impl.cc
+++ b/src/rtc_video_device_impl.cc
@@ -40,11 +40,16 @@ scoped_refptr<RTCVideoCapturer> RTCVideoDeviceImpl::Create(const char* name,
                                                            size_t width,
                                                            size_t height,
                                                            size_t target_fps) {
-  return signaling_thread_->Invoke<scoped_refptr<RTCVideoCapturerImpl>>(
-      RTC_FROM_HERE,[&, index] {
+  
+    auto vcm = webrtc::internal::VcmCapturer::Create(width, height, target_fps, index);
+    if (vcm == nullptr) {
+        return nullptr;
+    }
+
+    return signaling_thread_->Invoke<scoped_refptr<RTCVideoCapturerImpl>>(
+      RTC_FROM_HERE,[vcm] {
       return scoped_refptr<RTCVideoCapturerImpl>(
-          new RefCountedObject<RTCVideoCapturerImpl>(absl::WrapUnique(webrtc::internal::VcmCapturer::Create(
-                    width, height, target_fps, index))));
+          new RefCountedObject<RTCVideoCapturerImpl>(absl::WrapUnique(vcm)));
       });
 }
 


### PR DESCRIPTION
Check if capturer creation returns null.