### PR TITLE
use raw pointer to uint8_t memory instead of custom "portable" string…

### DIFF
--- a/include/rtc_data_channel.h
+++ b/include/rtc_data_channel.h
@@ -34,7 +34,7 @@ class RTCDataChannelObserver {
 
 class RTCDataChannel : public RefCountInterface {
  public:
-  virtual void Send(const string data, bool binary = false) = 0;
+  virtual void Send(const uint8_t* data, uint32_t size, bool binary = false) = 0;
 
   virtual void Close() = 0;
 

--- a/src/rtc_data_channel_impl.cc
+++ b/src/rtc_data_channel_impl.cc
@@ -9,15 +9,11 @@ RTCDataChannelImpl::RTCDataChannelImpl(
   label_ = rtc_data_channel_->label();
 }
 
-void RTCDataChannelImpl::Send(const string data, bool binary /*= false*/) {
-  if (binary) {
-    rtc::CopyOnWriteBuffer binary(to_std_string(data));
-    webrtc::DataBuffer buffer(binary, true);
-    rtc_data_channel_->Send(buffer);
-  } else {
-    webrtc::DataBuffer buffer(to_std_string(data));
-    rtc_data_channel_->Send(buffer);
-  }
+void RTCDataChannelImpl::Send(const uint8_t* data, uint32_t size, bool binary /*= false*/) {
+  
+    rtc::CopyOnWriteBuffer copyOnWriteBuffer(data, size);
+    webrtc::DataBuffer buffer(copyOnWriteBuffer, binary);
+    rtc_data_channel_->Send(buffer);  
 }
 
 void RTCDataChannelImpl::Close() {

--- a/src/rtc_data_channel_impl.h
+++ b/src/rtc_data_channel_impl.h
@@ -3,7 +3,6 @@
 
 #include "rtc_data_channel.h"
 #include "rtc_types.h"
-
 #include "api/data_channel_interface.h"
 #include "rtc_base/synchronization/mutex.h"
 
@@ -15,7 +14,7 @@ class RTCDataChannelImpl : public RTCDataChannel,
   RTCDataChannelImpl(
       rtc::scoped_refptr<webrtc::DataChannelInterface> rtc_data_channel);
 
-  virtual void Send(const string data, bool binary = false) override;
+  virtual void Send(const uint8_t* data, uint32_t size, bool binary = false) override;
 
   virtual void Close() override;
 


### PR DESCRIPTION
Related to https://github.com/flutter-webrtc/flutter-webrtc/issues/908 the current implementation does not handle binary data correctly if it contains zero or "null" bytes as the string class that is used in the interface doesn't care for this type of data and shouldn't care for that.

I replaced the interface with a raw pointer instead of e.g. a std::vector<uint8_t> to avoid dll boundary issues.