### PR TITLE
disable desktop source on linux

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -25,7 +25,6 @@ rtc_shared_library("libwebrtc"){
     "include/rtc_audio_track.h",
     "include/rtc_audio_source.h",
     "include/rtc_data_channel.h",
-    "include/rtc_desktop_device.h",
     "include/rtc_ice_candidate.h",
     "include/rtc_media_stream.h",
     "include/rtc_media_track.h",
@@ -63,8 +62,6 @@ rtc_shared_library("libwebrtc"){
     "src/rtc_audio_track_impl.cc",
     "src/rtc_data_channel_impl.h",
     "src/rtc_data_channel_impl.cc",
-    "src/rtc_desktop_device_impl.h",
-    "src/rtc_desktop_device_impl.cc",
     "src/rtc_ice_candidate_impl.h",
     "src/rtc_ice_candidate_impl.cc",
     "src/rtc_peerconnection_impl.h",
@@ -91,8 +88,7 @@ rtc_shared_library("libwebrtc"){
     "src/internal/video_capturer.cc",
     "src/internal/vcm_capturer.h",
     "src/internal/vcm_capturer.cc",
-    "src/interanl/desktop_capturer.h",
-    "src/internal/desktop_capturer.cc",
+
     "src/rtc_rtp_sender_impl.cc",
     "src/rtc_rtp_sender_impl.h",
     "src/rtc_rtp_transceiver_impl.cc",
@@ -150,7 +146,6 @@ rtc_shared_library("libwebrtc"){
   defines = [ 
     "USE_LIBYUV",
     "WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE",
-    "USE_INTEL_MEDIA_SDK",
   ]
 
   if(is_win) {
@@ -190,7 +185,6 @@ rtc_shared_library("libwebrtc"){
       "../media:rtc_media",
       "../media:rtc_media_base",
       "../modules/audio_device:audio_device",
-      "../modules/desktop_capture",
       "../modules/audio_processing:api",
       "../modules/audio_processing:audio_processing",
       "../modules/video_capture:video_capture_module",
@@ -201,6 +195,18 @@ rtc_shared_library("libwebrtc"){
   ]
   libs = []
 
+
+  if(is_win) {
+    defines += [ "RTC_DESKTOP_DEVICE"]
+    sources += [
+      "include/rtc_desktop_device.h",
+      "src/rtc_desktop_device_impl.h",
+      "src/rtc_desktop_device_impl.cc",    
+      "src/interanl/desktop_capturer.h",
+      "src/internal/desktop_capturer.cc",      
+    ]
+     deps += ["../modules/desktop_capture"]
+  }
   if(is_win) {
     libs += [ "libmfx_vs2015.lib" ]
     lib_dirs = [ "src\win\lib\x64" ]

--- a/include/rtc_peerconnection_factory.h
+++ b/include/rtc_peerconnection_factory.h
@@ -32,9 +32,9 @@ class RTCPeerConnectionFactory : public RefCountInterface {
   virtual scoped_refptr<RTCAudioDevice> GetAudioDevice() = 0;
 
   virtual scoped_refptr<RTCVideoDevice> GetVideoDevice() = 0;
-
+#ifdef RTC_DESKTOP_DEVICE 
   virtual scoped_refptr<RTCDesktopDevice>  GetDesktopDevice() = 0;
-
+#endif
   virtual scoped_refptr<RTCAudioSource> CreateAudioSource(
       const string audio_source_label) = 0;
 
@@ -42,12 +42,12 @@ class RTCPeerConnectionFactory : public RefCountInterface {
       scoped_refptr<RTCVideoCapturer> capturer,
       const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) = 0;
-
+#ifdef RTC_DESKTOP_DEVICE 
   virtual scoped_refptr<RTCVideoSource> CreateDesktopSource(
       scoped_refptr<RTCDesktopCapturer> capturer,
       const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) = 0;
-
+#endif
   virtual scoped_refptr<RTCAudioTrack> CreateAudioTrack(
       scoped_refptr<RTCAudioSource> source,
       const string track_id) = 0;

--- a/src/rtc_peerconnection_factory_impl.cc
+++ b/src/rtc_peerconnection_factory_impl.cc
@@ -157,7 +157,7 @@ scoped_refptr<RTCAudioSource> RTCPeerConnectionFactoryImpl::CreateAudioSource(
       new RefCountedObject<RTCAudioSourceImpl>(rtc_source_track));
   return source;
 }
-
+#ifdef RTC_DESKTOP_DEVICE   
 scoped_refptr<RTCDesktopDevice>
 RTCPeerConnectionFactoryImpl::GetDesktopDevice() {
   if (!desktop_device_impl_) {
@@ -166,7 +166,7 @@ RTCPeerConnectionFactoryImpl::GetDesktopDevice() {
   }
   return desktop_device_impl_;
 }
-
+#endif
 scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource(
     scoped_refptr<RTCVideoCapturer> capturer,
     const string video_source_label,
@@ -202,6 +202,7 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_s(
   return source;
 }
 
+#ifdef RTC_DESKTOP_DEVICE   
 scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateDesktopSource(
     scoped_refptr<RTCDesktopCapturer> capturer,
     const string video_source_label,
@@ -225,7 +226,7 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_d(
     scoped_refptr<RTCDesktopCapturer> capturer,
     const char* video_source_label,
     scoped_refptr<RTCMediaConstraints> constraints) {
-
+  
   RTCDesktopCapturerImpl* capturer_impl =
       static_cast<RTCDesktopCapturerImpl*>(capturer.get());
 
@@ -241,6 +242,7 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_d(
 
   return source;
 }
+#endif
 
 scoped_refptr<RTCMediaStream> RTCPeerConnectionFactoryImpl::CreateStream(
     const string stream_id) {

--- a/src/rtc_peerconnection_factory_impl.h
+++ b/src/rtc_peerconnection_factory_impl.h
@@ -2,7 +2,9 @@
 #define LIB_WEBRTC_MEDIA_SESSION_FACTORY_IMPL_HXX
 
 #include "rtc_audio_device_impl.h"
+#ifdef RTC_DESKTOP_DEVICE 
 #include "rtc_desktop_device_impl.h"
+#endif
 #include "rtc_peerconnection.h"
 #include "rtc_peerconnection_factory.h"
 #include "rtc_video_device_impl.h"
@@ -44,14 +46,14 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
       scoped_refptr<RTCVideoCapturer> capturer,
       const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) override;
-    
+#ifdef RTC_DESKTOP_DEVICE 
   virtual scoped_refptr<RTCVideoSource> CreateDesktopSource(
       scoped_refptr<RTCDesktopCapturer> capturer,
       const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) override;
 
   virtual scoped_refptr<RTCDesktopDevice> GetDesktopDevice() override;
-
+#endif
   virtual scoped_refptr<RTCAudioTrack> CreateAudioTrack(
       scoped_refptr<RTCAudioSource> source,
       const string track_id) override;
@@ -92,7 +94,9 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
   rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module_;
   scoped_refptr<AudioDeviceImpl> audio_device_impl_;
   scoped_refptr<RTCVideoDeviceImpl> video_device_impl_;
+#ifdef RTC_DESKTOP_DEVICE   
   scoped_refptr<RTCDesktopDeviceImpl> desktop_device_impl_;
+#endif
   std::list<scoped_refptr<RTCPeerConnection>> peerconnections_;
   std::unique_ptr<webrtc::TaskQueueFactory> task_queue_factory_;
 };


### PR DESCRIPTION
The latest capture screen code cannot be compiled in linux, this modification is to disable screen captures in linux.