### PR TITLE
选择音频设备时使用PostTask调用，防止在OnDeviceChange直接调用而死锁。

### DIFF
--- a/src/rtc_audio_device_impl.cc
+++ b/src/rtc_audio_device_impl.cc
@@ -40,32 +40,33 @@ int32_t AudioDeviceImpl::RecordingDeviceName(uint16_t index,
 }
 
 int32_t AudioDeviceImpl::SetPlayoutDevice(uint16_t index) {
-  return worker_thread_->Invoke<int32_t>(RTC_FROM_HERE, [&] {
+  worker_thread_->PostTask([this,index] {
     RTC_DCHECK_RUN_ON(worker_thread_);
     if (audio_device_module_->Playing()) {
       audio_device_module_->StopPlayout();
       audio_device_module_->SetPlayoutDevice(index);
       audio_device_module_->InitPlayout();
-      return audio_device_module_->StartPlayout();
+      audio_device_module_->StartPlayout();
     } else {
-      return audio_device_module_->SetPlayoutDevice(index);
+      audio_device_module_->SetPlayoutDevice(index);
     }
-
   });
+  return 0;
 }
 
 int32_t AudioDeviceImpl::SetRecordingDevice(uint16_t index) {
-  return worker_thread_->Invoke<int32_t>(RTC_FROM_HERE, [&] {
+  worker_thread_->PostTask([this,index] {
     RTC_DCHECK_RUN_ON(worker_thread_);
     if (audio_device_module_->Recording()) {
       audio_device_module_->StopRecording();
       audio_device_module_->SetRecordingDevice(index);
       audio_device_module_->InitRecording();
-      return audio_device_module_->StartRecording();
+      audio_device_module_->StartRecording();
     } else {
-      return audio_device_module_->SetRecordingDevice(index);
+      audio_device_module_->SetRecordingDevice(index);
     }
   });
+  return 0;
 }
 
 int32_t AudioDeviceImpl::OnDeviceChange(OnDeviceChangeCallback listener) {


### PR DESCRIPTION
在OnDeviceChange的回调中直接调用 SetPlayoutDevice ，SetRecordingDevice 会死锁。