### PR TITLE
Move threads code  to rtc_peerconnection_factory

### DIFF
--- a/src/libwebrtc.cc
+++ b/src/libwebrtc.cc
@@ -10,37 +10,12 @@ namespace libwebrtc {
 
 // Initialize static variable g_is_initialized to false.
 static bool g_is_initialized = false;
-// Thread pointers for different thread types.
-std::unique_ptr<rtc::Thread> worker_thread;
-std::unique_ptr<rtc::Thread> signaling_thread;
-std::unique_ptr<rtc::Thread> network_thread;
 
-// Initializes SSL and the required threads, if not initialized.
+// Initializes SSL, if not initialized.
 bool LibWebRTC::Initialize() {
   if (!g_is_initialized) {
     rtc::InitializeSSL();
     g_is_initialized = true;
-
-    // Creates and starts the worker thread.
-    if (worker_thread.get() == nullptr) {
-      worker_thread = rtc::Thread::Create();
-      worker_thread->SetName("worker_thread", nullptr);
-      RTC_CHECK(worker_thread->Start()) << "Failed to start thread";
-    }
-
-    // Creates and starts the signaling thread.
-    if (signaling_thread.get() == nullptr) {
-      signaling_thread = rtc::Thread::Create();
-      signaling_thread->SetName("signaling_thread", NULL);
-      RTC_CHECK(signaling_thread->Start()) << "Failed to start thread";
-    }
-
-    // Creates and starts the network thread.
-    if (network_thread.get() == nullptr) {
-      network_thread = rtc::Thread::CreateWithSocketServer();
-      network_thread->SetName("network_thread", nullptr);
-      RTC_CHECK(network_thread->Start()) << "Failed to start thread";
-    }
   }
   return g_is_initialized;
 }
@@ -49,24 +24,6 @@ bool LibWebRTC::Initialize() {
 void LibWebRTC::Terminate() {
   rtc::ThreadManager::Instance()->SetCurrentThread(NULL);
   rtc::CleanupSSL();
-
-  // Stops and resets the worker thread.
-  if (worker_thread.get() != nullptr) {
-    worker_thread->Stop();
-    worker_thread.reset(nullptr);
-  }
-
-  // Stops and resets the signaling thread.
-  if (signaling_thread.get() != nullptr) {
-    signaling_thread->Stop();
-    signaling_thread.reset(nullptr);
-  }
-
-  // Stops and resets the network thread.
-  if (network_thread.get() != nullptr) {
-    network_thread->Stop();
-    network_thread.reset(nullptr);
-  }
 
   // Resets the static variable g_is_initialized to false.
   g_is_initialized = false;
@@ -77,9 +34,7 @@ scoped_refptr<RTCPeerConnectionFactory>
 LibWebRTC::CreateRTCPeerConnectionFactory() {
   scoped_refptr<RTCPeerConnectionFactory> rtc_peerconnection_factory =
       scoped_refptr<RTCPeerConnectionFactory>(
-          new RefCountedObject<RTCPeerConnectionFactoryImpl>(
-              worker_thread.get(), signaling_thread.get(),
-              network_thread.get()));
+          new RefCountedObject<RTCPeerConnectionFactoryImpl>());
   rtc_peerconnection_factory->Initialize();
   return rtc_peerconnection_factory;
 }

--- a/src/rtc_peerconnection_factory_impl.h
+++ b/src/rtc_peerconnection_factory_impl.h
@@ -22,9 +22,7 @@ namespace libwebrtc {
 
 class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
  public:
-  RTCPeerConnectionFactoryImpl(rtc::Thread* worker_thread,
-                               rtc::Thread* signaling_thread,
-                               rtc::Thread* network_thread);
+  RTCPeerConnectionFactoryImpl();
 
   virtual ~RTCPeerConnectionFactoryImpl();
 
@@ -94,9 +92,9 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
       scoped_refptr<RTCMediaConstraints> constraints);
 #endif
  private:
-  rtc::Thread* worker_thread_ = nullptr;
-  rtc::Thread* signaling_thread_ = nullptr;
-  rtc::Thread* network_thread_ = nullptr;
+  std::unique_ptr<rtc::Thread> worker_thread_;
+  std::unique_ptr<rtc::Thread> signaling_thread_;
+  std::unique_ptr<rtc::Thread> network_thread_;
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>
       rtc_peerconnection_factory_;
   rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module_;


### PR DESCRIPTION
All threads are used in peerconnection_factory, It is easy to manage all the threads if move all threads to peerconnection_factory.