### PR TITLE
Feat/conan support

### DIFF
--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.2.0)
+project(test_package CXX)
+
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
+
+find_package(libwebrtc REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} libwebrtc::libwebrtc)

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain"
+    generators = "CMakeDeps"
 
 
     def requirements(self):

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from conan import ConanFile
+from conan.tools.cmake import CMake
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain"
+
+
+    def requirements(self):
+        self.requires("libwebrtc/0.0.1")
+
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+
+    def test(self):
+        pass

--- a/.conan/test_package/main.cpp
+++ b/.conan/test_package/main.cpp
@@ -1,0 +1,15 @@
+#include <libwebrtc.h>
+
+using namespace libwebrtc;
+
+int main()
+{
+    LibWebRTC::Initialize();
+
+    auto pPeerConnectionFactory = LibWebRTC::CreateRTCPeerConnectionFactory();
+    pPeerConnectionFactory->Initialize();
+
+    pPeerConnectionFactory->Terminate();
+
+    LibWebRTC::Terminate();
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,169 @@
+import fileinput
+from conan import ConanFile
+from conan.tools.files import chdir, mkdir, save, load
+import pathlib
+import os
+
+
+class LibWebRTCConan(ConanFile):
+    name = 'libwebrtc'
+    version = '0.0.1'
+    settings = 'os', 'build_type', 'arch'
+    generators = [ "CMakeDeps" ]
+
+    depot_tools_repository = 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
+    depot_tools_release = 'a104c01252f54997e672490e7ab6cb7e15295a98'
+    depot_tools_dir = 'depot_tools'
+    
+    webrtc_release = 'm104'
+    webrtc_dir = 'webrtc'
+
+
+    def setup_depot_tools(self):
+        try:
+            with chdir(self, self.depot_tools_dir):
+                print('-- Depot tools directory already exists')
+        except:
+            print('-- Setting up depot tools')
+
+            self.run(f'git clone {self.depot_tools_repository} {self.depot_tools_dir}')
+
+            # gclient has to be called twice, on windows if it's called once, 
+            # after a switch to specified branch there are issue with python paths
+            with chdir(self, self.depot_tools_dir):
+                os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
+
+                self.run('gclient')
+
+                self.run(f'git checkout {self.depot_tools_release}')
+
+                os.environ['DEPOT_TOOLS_UPDATE'] = '0'
+
+                self.run('gclient')
+
+
+    def set_depot_tools_environment_variables(self):
+        current_path = pathlib.Path(__file__).parent.resolve()
+        depot_tools_path = os.path.join(os.path.sep, str(current_path), 'build','externals', self.depot_tools_dir)
+        os.environ['PATH'] += os.pathsep + depot_tools_path
+        os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
+        os.environ['DEPOT_TOOLS_UPDATE'] = '0'
+
+
+    def create_gclient_configuration(self):
+        gclientFileContent = """\
+solutions = [
+  {{
+    "name"        : '{}',
+    "url"         : 'https://github.com/webrtc-sdk/webrtc.git@{}_release',
+    "deps_file"   : 'DEPS',
+    "managed"     : False,
+    "custom_deps" : {{}},
+    "custom_vars": {{}},
+  }},
+]
+""".format(self.webrtc_dir, self.webrtc_release)
+
+        with open('.gclient', 'w') as file:
+            file.writelines(gclientFileContent)
+
+
+    def setup_webrtc(self):
+        try:
+           with chdir(self, self.webrtc_dir):
+               return
+        except:
+           print('-- Setting up WebRTC')
+
+        self.create_gclient_configuration()
+        
+        self.run('gclient sync')
+
+
+    def source(self):
+        mkdir(self, "build")
+        with chdir(self, 'build'):
+            mkdir(self, "externals")
+            with chdir(self, 'externals'):
+                self.setup_depot_tools()
+
+                self.set_depot_tools_environment_variables()
+
+                self.setup_webrtc()
+
+
+    def setup_webrtc_on_linux(self):
+        self.run('sed -i "s/} snapcraft/} /gi" build/install-build-deps.sh')
+        self.run('build/install-build-deps.sh --no-prompt')
+
+        if self.settings.arch == 'x86_64':
+            self.run('python3 build/linux/sysroot_scripts/install-sysroot.py --arch=amd64')
+        elif self.settings.arch == 'armv8':
+            self.run('python3 build/linux/sysroot_scripts/install-sysroot.py --arch=arm64')
+        else:
+            raise 'Unsupported Linux distribution'
+
+
+    def configure_webrtc(self):
+        try:
+            load(self, 'webrtc_configuration_lock')
+            return
+        except:
+           print('-- Configure WebRTC')
+
+        with chdir(self, self.webrtc_dir):
+            if self.settings.os == 'Linux':
+                self.setup_webrtc_on_linux()
+
+            with fileinput.FileInput('BUILD.gn', inplace=True) as file:
+                for line in file:
+                    print(line.replace("deps = [ \":webrtc\" ]", "deps = [ \":webrtc\", \"../../../libwebrtc\" ]"), end='')
+
+        save(self, 'webrtc_configuration_lock', '')
+
+
+    def gn_args(self):
+        args = []
+
+        args.append('is_clang=true')
+        args.append('is_debug=false')
+        args.append('rtc_include_tests=false')
+        args.append('is_component_build=false')
+        args.append('rtc_use_h264=true')
+        args.append('ffmpeg_branding=\"Chrome\"')
+
+        if self.settings.os == 'Windows':
+            args.append('target_os=\"win\"')
+            args.append('libwebrtc_desktop_capture=true')
+
+        if self.settings.os == 'Linux':
+            args.append('target_os=\"linux\"')
+
+            if self.settings.arch == 'x86_64':
+                args.append('target_cpu=\"x64\"')
+            elif self.settings.arch == 'armv8':
+                args.append('target_cpu=\"arm64\"')
+            else:
+                raise 'Unsupported Linux distribution'
+
+        return " ".join(args)
+
+
+    def build_webrtc(self):
+        with chdir(self, 'src'):
+            gn_args = self.gn_args()
+
+            self.run(f'gn gen out --args="{gn_args}"')
+
+            self.run("ninja -C out")
+
+            self.run("ninja -C out libwebrtc")
+
+
+    def build(self):
+        with chdir(self, 'externals'):
+            self.set_depot_tools_environment_variables()
+
+            self.configure_webrtc()
+
+            self.build_webrtc()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import fileinput
 from conan import ConanFile
 from conan.tools.files import chdir, copy
@@ -38,6 +40,7 @@ class LibWebRTCConan(ConanFile):
     def export_sources(self):
         destination_path = os.path.join(os.path.sep, self.export_sources_path, self.webrtc_dir, self.name)
         
+        copy(self, "LICENSE", self.recipe_folder, destination_path)
         copy(self, "BUILD.gn", self.recipe_folder, destination_path)
         
         headers = os.path.join(os.path.sep, self.recipe_folder, "include")
@@ -104,7 +107,7 @@ solutions = [
     def _setup_webrtc(self):
         self._create_gclient_configuration()
         
-        self.run('gclient sync')
+        self.run('gclient sync --jobs 16')
 
         with chdir(self, 'src'):
             if self.settings.os == 'Linux':
@@ -185,13 +188,15 @@ solutions = [
 
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        sources_folder = os.path.join(self.build_folder, 'src', 'libwebrtc')
+        copy(self, pattern="LICENSE", src=sources_folder, dst=os.path.join(self.package_folder, "licenses"))
         
-        copy(self, "*.h", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
-        copy(self, "*.h", src=os.path.join(self.source_folder, "include", "base"), dst=os.path.join(self.package_folder, "include", "base"))
+        copy(self, '*.h', src=os.path.join(sources_folder, 'include'), dst=os.path.join(self.package_folder, 'include'))
+        copy(self, '*.h', src=os.path.join(sources_folder, 'include', 'base'), dst=os.path.join(self.package_folder, 'include', 'base'))
 
-        copy(self, "libwebrtc.dll", src=os.path.join(self.build_folder, "out"), dst=os.path.join(self.package_folder, "lib"))
-        copy(self, "libwebrtc.so", src=os.path.join(self.build_folder, "out"), dst=os.path.join(self.package_folder, "lib"))
+        copy(self, 'libwebrtc.dll.lib', src=os.path.join(self.build_folder, 'src', 'out'), dst=os.path.join(self.package_folder, 'lib'), keep_path=False)
+        copy(self, 'libwebrtc.dll', src=os.path.join(self.build_folder, 'src', 'out'), dst=os.path.join(self.package_folder, 'bin'), keep_path=False)
+        copy(self, 'libwebrtc.so', src=os.path.join(self.build_folder, 'src', 'out'), dst=os.path.join(self.package_folder, 'lib'), keep_path=False)
 
 
     def package_info(self):
@@ -199,3 +204,4 @@ solutions = [
         
         self.cpp_info.libdirs = ["lib"]
         self.cpp_info.libs = ["libwebrtc"]
+        self.cpp_info.libs = ["libwebrtc.dll"]


### PR DESCRIPTION
@cloudwebrtc Could you take a look, and give your thoughts?

To test it locally, ensure that you do not have any depot_tools related things in your ENV.
The package is designed to work with the latest version of Conan ( 2.0 ).
To test it out, ensure you have installed latest version of Conan.
In the repository root: 
`conan create .`

It will:
1. Export local sources required for building to the build directory
2. Download depot tools
3. Checkout to correct depot tools version
4. Download google WebRTC start
5. Download dependencies
6. Build libwebrtc
7. Create and export package to LOCAL cache

There is test_package directory, with minimal cmake which import and use package which was built.
To run it go to the <root>/.conan/test_package directory, and call:
```
conan install . --output-folder=build
conan build . --output-folder=build
```
First step will import package, and second will build test app.

Extra reading about conan creation package can be found [here](https://docs.conan.io/2/tutorial/developing_packages/local_package_development_flow.html).

As for now I have tested it on Windows, in the next few days I will check if everything is ok with Linux.