### PR TITLE
rtc_data_channel_ may generate illegal callbacks

### DIFF
--- a/src/rtc_data_channel_impl.cc
+++ b/src/rtc_data_channel_impl.cc
@@ -9,6 +9,10 @@ RTCDataChannelImpl::RTCDataChannelImpl(
   label_ = rtc_data_channel_->label();
 }
 
+RTCDataChannelImpl::~RTCDataChannelImpl() {
+  rtc_data_channel_->UnregisterObserver();
+};
+
 void RTCDataChannelImpl::Send(const uint8_t* data,
                               uint32_t size,
                               bool binary /*= false*/) {

--- a/src/rtc_data_channel_impl.h
+++ b/src/rtc_data_channel_impl.h
@@ -35,6 +35,8 @@ class RTCDataChannelImpl : public RTCDataChannel,
   }
 
  protected:
+  virtual ~RTCDataChannelImpl();
+
   virtual void OnStateChange() override;
 
   virtual void OnMessage(const webrtc::DataBuffer& buffer) override;


### PR DESCRIPTION
After RTCDataChannelImpl is released, rtc_data_channel_ may generate illegal callbacks.
在RTCDataChannelImpl 被提前释放后，成员rtc_data_channel_ 的OnStateChange回调会异常