### PR TITLE
Fix the crash issue for invalid candidate or session description

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,3 @@
-# Defines the Chromium style for automatic reformatting.
-# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
-BasedOnStyle: Chromium
-# This defaults to 'Auto'. Explicitly set it for a while, so that
-# 'vector<vector<int> >' in existing files gets formatted to
-# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
-# 'int>>' if the file already contains at least one such instance.)
-Standard: Cpp11
-SortIncludes: true
----
-Language: ObjC
-ColumnLimit: 100
+# DON'T delete this file as it helps developers format C++ code in
+# IDEs such as VSCode.
+BasedOnStyle: Google

--- a/format.sh
+++ b/format.sh
@@ -6,4 +6,4 @@
 # root directory of the project. The "-i" option overwrites the original files with 
 # the formatted version.
 find . -name "*.cc" -o -name "*.h" | xargs dos2unix
-find . -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
+find . -name "*.cc" -o -name "*.h" | xargs clang-format -style=google -i

--- a/include/base/fixed_size_function.h
+++ b/include/base/fixed_size_function.h
@@ -56,29 +56,24 @@ struct fixed_function_vtable<construct_type::copy_and_move, Ret, Args...>
 
 }  // namespace details
 
-template <typename Function,
-          size_t MaxSize = 128,
+template <typename Function, size_t MaxSize = 128,
           construct_type ConstructStrategy = construct_type::copy_and_move>
 class fixed_size_function;
 
-template <typename Ret,
-          typename... Args,
-          size_t MaxSize,
+template <typename Ret, typename... Args, size_t MaxSize,
           construct_type ConstructStrategy>
 class fixed_size_function<Ret(Args...), MaxSize, ConstructStrategy> {
  public:
   // Compile-time information
 
   using is_copyable =
-      std::integral_constant<bool,
-                             ConstructStrategy == construct_type::copy ||
-                                 ConstructStrategy ==
-                                     construct_type::copy_and_move>;
+      std::integral_constant<bool, ConstructStrategy == construct_type::copy ||
+                                       ConstructStrategy ==
+                                           construct_type::copy_and_move>;
   using is_movable =
-      std::integral_constant<bool,
-                             ConstructStrategy == construct_type::move ||
-                                 ConstructStrategy ==
-                                     construct_type::copy_and_move>;
+      std::integral_constant<bool, ConstructStrategy == construct_type::move ||
+                                       ConstructStrategy ==
+                                           construct_type::copy_and_move>;
 
   using result_type = Ret;
 

--- a/include/base/portable.h
+++ b/include/base/portable.h
@@ -82,9 +82,7 @@ class string {
   }
 };
 
-inline std::string to_std_string(const string& str) {
-  return str.std_string();
-}
+inline std::string to_std_string(const string& str) { return str.std_string(); }
 
 template <typename T>
 class identity {
@@ -244,8 +242,7 @@ class map {
   }*/
 
   template <typename K2, typename KC, typename V2, typename VC>
-  static my_pair* to_array(const std::map<K2, V2>& m,
-                           KC convertKey,
+  static my_pair* to_array(const std::map<K2, V2>& m, KC convertKey,
                            VC convertValue) {
     my_pair* data = new my_pair[m.size()];
     my_pair* dp = data;
@@ -278,8 +275,7 @@ class map {
       : m_vec(to_array(m, identity<K>(), identity<V>()), m.size()) {}
 
   template <typename K2, typename KC, typename V2, typename VC>
-  map(const std::map<K2, V2>& m,
-      KC convertKey = identity<K>(),
+  map(const std::map<K2, V2>& m, KC convertKey = identity<K>(),
       VC convertValue = identity<V>())
       : m_vec(to_array(m, convertKey, convertValue), m.size()) {}
 
@@ -320,8 +316,7 @@ class map {
   const my_pair* get(K2 key, int (*cmp)(K2, const K&)) const {
     for (size_t i = 0; i < m_vec.size(); ++i) {
       const my_pair* dp = m_vec.data() + i;
-      if (!cmp(key, dp->key))
-        return dp;
+      if (!cmp(key, dp->key)) return dp;
     }
     return 0;
   }
@@ -428,14 +423,12 @@ class local_ptr {
       : m_ptr(0), m_destroy(0) {}  // copying does not persist value
   local_ptr& operator=(const local_ptr&) { return *this; }
   ~local_ptr() {
-    if (m_ptr)
-      m_destroy(m_ptr);
+    if (m_ptr) m_destroy(m_ptr);
   }
   const T* get() const { return m_ptr; }
   T* get() { return m_ptr; }
   void set(T* ptr, void (*dtor)(T*)) {
-    if (m_ptr)
-      m_destroy(m_ptr);
+    if (m_ptr) m_destroy(m_ptr);
     m_ptr = ptr;
     m_destroy = dtor;
   }

--- a/include/base/refcountedobject.h
+++ b/include/base/refcountedobject.h
@@ -26,8 +26,7 @@ class RefCountedObject : public T {
 
   template <class P0, class P1, class... Args>
   RefCountedObject(P0&& p0, P1&& p1, Args&&... args)
-      : T(std::forward<P0>(p0),
-          std::forward<P1>(p1),
+      : T(std::forward<P0>(p0), std::forward<P1>(p1),
           std::forward<Args>(args)...) {}
 
   virtual int AddRef() const { return AtomicOps::Increment(&ref_count_); }

--- a/include/base/scoped_ref_ptr.h
+++ b/include/base/scoped_ref_ptr.h
@@ -73,19 +73,16 @@ class scoped_refptr {
   scoped_refptr() : ptr_(NULL) {}
 
   scoped_refptr(T* p) : ptr_(p) {
-    if (ptr_)
-      ptr_->AddRef();
+    if (ptr_) ptr_->AddRef();
   }
 
   scoped_refptr(const scoped_refptr<T>& r) : ptr_(r.ptr_) {
-    if (ptr_)
-      ptr_->AddRef();
+    if (ptr_) ptr_->AddRef();
   }
 
   template <typename U>
   scoped_refptr(const scoped_refptr<U>& r) : ptr_(r.get()) {
-    if (ptr_)
-      ptr_->AddRef();
+    if (ptr_) ptr_->AddRef();
   }
 
   // Move constructors.
@@ -95,8 +92,7 @@ class scoped_refptr {
   scoped_refptr(scoped_refptr<U>&& r) : ptr_(r.release()) {}
 
   ~scoped_refptr() {
-    if (ptr_)
-      ptr_->Release();
+    if (ptr_) ptr_->Release();
   }
 
   T* get() const { return ptr_; }
@@ -116,10 +112,8 @@ class scoped_refptr {
 
   scoped_refptr<T>& operator=(T* p) {
     // AddRef first so that self assignment should work
-    if (p)
-      p->AddRef();
-    if (ptr_)
-      ptr_->Release();
+    if (p) p->AddRef();
+    if (ptr_) ptr_->Release();
     ptr_ = p;
     return *this;
   }

--- a/include/rtc_audio_frame.h
+++ b/include/rtc_audio_frame.h
@@ -23,8 +23,7 @@ class AudioFrame {
    * @param num_channels: the number of audio channels.
    * @return AudioFrame*: a pointer to the newly created AudioFrame.
    */
-  MEDIA_MANAGER_API static AudioFrame* Create(int id,
-                                              uint32_t timestamp,
+  MEDIA_MANAGER_API static AudioFrame* Create(int id, uint32_t timestamp,
                                               const int16_t* data,
                                               size_t samples_per_channel,
                                               int sample_rate_hz,
@@ -45,11 +44,8 @@ class AudioFrame {
    * @param sample_rate_hz: the sample rate in Hz.
    * @param num_channels: the number of audio channels.
    */
-  virtual void UpdateFrame(int id,
-                           uint32_t timestamp,
-                           const int16_t* data,
-                           size_t samples_per_channel,
-                           int sample_rate_hz,
+  virtual void UpdateFrame(int id, uint32_t timestamp, const int16_t* data,
+                           size_t samples_per_channel, int sample_rate_hz,
                            size_t num_channels = 1) = 0;
 
   /**

--- a/include/rtc_data_channel.h
+++ b/include/rtc_data_channel.h
@@ -74,8 +74,7 @@ class RTCDataChannel : public RefCountInterface {
    * The data buffer, its size, and a boolean indicating whether the data is
    * binary are passed as parameters.
    */
-  virtual void Send(const uint8_t* data,
-                    uint32_t size,
+  virtual void Send(const uint8_t* data, uint32_t size,
                     bool binary = false) = 0;
 
   /**

--- a/include/rtc_desktop_capturer.h
+++ b/include/rtc_desktop_capturer.h
@@ -63,10 +63,7 @@ class RTCDesktopCapturer : public RefCountInterface {
    *
    * @return The current capture state after attempting to start capture.
    */
-  virtual CaptureState Start(uint32_t fps,
-                             uint32_t x,
-                             uint32_t y,
-                             uint32_t w,
+  virtual CaptureState Start(uint32_t fps, uint32_t x, uint32_t y, uint32_t w,
                              uint32_t h) = 0;
 
   /**

--- a/include/rtc_dtmf_sender.h
+++ b/include/rtc_dtmf_sender.h
@@ -25,13 +25,10 @@ class RTCDtmfSender : public RefCountInterface {
 
   virtual void UnregisterObserver() = 0;
 
-  virtual bool InsertDtmf(const string tones,
-                          int duration,
+  virtual bool InsertDtmf(const string tones, int duration,
                           int inter_tone_gap) = 0;
 
-  virtual bool InsertDtmf(const string tones,
-                          int duration,
-                          int inter_tone_gap,
+  virtual bool InsertDtmf(const string tones, int duration, int inter_tone_gap,
                           int comma_delay) = 0;
 
   virtual bool CanInsertDtmf() = 0;

--- a/include/rtc_frame_cryptor.h
+++ b/include/rtc_frame_cryptor.h
@@ -36,7 +36,7 @@ struct KeyProviderOptions {
 class KeyProvider : public RefCountInterface {
  public:
   LIB_WEBRTC_API static scoped_refptr<KeyProvider> Create(KeyProviderOptions*);
-  
+
   virtual bool SetSharedKey(int index, vector<uint8_t> key) = 0;
 
   virtual vector<uint8_t> RatchetSharedKey(int key_index) = 0;
@@ -44,8 +44,7 @@ class KeyProvider : public RefCountInterface {
   virtual vector<uint8_t> ExportSharedKey(int key_index) = 0;
 
   /// Set the key at the given index.
-  virtual bool SetKey(const string participant_id,
-                      int index,
+  virtual bool SetKey(const string participant_id, int index,
                       vector<uint8_t> key) = 0;
 
   virtual vector<uint8_t> RatchetKey(const string participant_id,
@@ -99,7 +98,7 @@ class RTCFrameCryptor : public RefCountInterface {
   virtual const string participant_id() const = 0;
 
   virtual void RegisterRTCFrameCryptorObserver(
-       scoped_refptr<RTCFrameCryptorObserver> observer) = 0;
+      scoped_refptr<RTCFrameCryptorObserver> observer) = 0;
 
   virtual void DeRegisterRTCFrameCryptorObserver() = 0;
 

--- a/include/rtc_ice_candidate.h
+++ b/include/rtc_ice_candidate.h
@@ -8,9 +8,7 @@ namespace libwebrtc {
 class RTCIceCandidate : public RefCountInterface {
  public:
   static LIB_WEBRTC_API scoped_refptr<RTCIceCandidate> Create(
-      const string sdp,
-      const string sdp_mid,
-      int sdp_mline_index,
+      const string sdp, const string sdp_mid, int sdp_mline_index,
       SdpParseError* error);
 
  public:

--- a/include/rtc_ice_transport.h
+++ b/include/rtc_ice_transport.h
@@ -66,8 +66,7 @@ class IceTransportFactory {
   virtual ~IceTransportFactory() = default;
 
   virtual scoped_refptr<IceTransport> CreateIceTransport(
-      const std::string& transport_name,
-      int component,
+      const std::string& transport_name, int component,
       IceTransportInit init) = 0;
 };
 

--- a/include/rtc_peerconnection.h
+++ b/include/rtc_peerconnection.h
@@ -179,8 +179,7 @@ class RTCPeerConnection : public RefCountInterface {
       const string stream_id) = 0;
 
   virtual scoped_refptr<RTCDataChannel> CreateDataChannel(
-      const string label,
-      RTCDataChannelInit* dataChannelDict) = 0;
+      const string label, RTCDataChannelInit* dataChannelDict) = 0;
 
   virtual void CreateOffer(OnSdpCreateSuccess success,
                            OnSdpCreateFailure failure,
@@ -194,13 +193,11 @@ class RTCPeerConnection : public RefCountInterface {
 
   virtual void Close() = 0;
 
-  virtual void SetLocalDescription(const string sdp,
-                                   const string type,
+  virtual void SetLocalDescription(const string sdp, const string type,
                                    OnSetSdpSuccess success,
                                    OnSetSdpFailure failure) = 0;
 
-  virtual void SetRemoteDescription(const string sdp,
-                                    const string type,
+  virtual void SetRemoteDescription(const string sdp, const string type,
                                     OnSetSdpSuccess success,
                                     OnSetSdpFailure failure) = 0;
 
@@ -210,8 +207,7 @@ class RTCPeerConnection : public RefCountInterface {
   virtual void GetRemoteDescription(OnGetSdpSuccess success,
                                     OnGetSdpFailure failure) = 0;
 
-  virtual void AddCandidate(const string mid,
-                            int mid_mline_index,
+  virtual void AddCandidate(const string mid, int mid_mline_index,
                             const string candiate) = 0;
 
   virtual void RegisterRTCPeerConnectionObserver(
@@ -242,15 +238,13 @@ class RTCPeerConnection : public RefCountInterface {
       scoped_refptr<RTCMediaTrack> track) = 0;
 
   virtual scoped_refptr<RTCRtpSender> AddTrack(
-      scoped_refptr<RTCMediaTrack> track,
-      const vector<string> streamIds) = 0;
+      scoped_refptr<RTCMediaTrack> track, const vector<string> streamIds) = 0;
 
   virtual scoped_refptr<RTCRtpTransceiver> AddTransceiver(
       RTCMediaType media_type) = 0;
 
   virtual scoped_refptr<RTCRtpTransceiver> AddTransceiver(
-      RTCMediaType media_type,
-      scoped_refptr<RTCRtpTransceiverInit> init) = 0;
+      RTCMediaType media_type, scoped_refptr<RTCRtpTransceiverInit> init) = 0;
 
   virtual bool RemoveTrack(scoped_refptr<RTCRtpSender> render) = 0;
 

--- a/include/rtc_peerconnection_factory.h
+++ b/include/rtc_peerconnection_factory.h
@@ -1,10 +1,9 @@
 #ifndef LIB_WEBRTC_RTC_PEERCONNECTION_FACTORY_HXX
 #define LIB_WEBRTC_RTC_PEERCONNECTION_FACTORY_HXX
 
-#include "rtc_types.h"
-
 #include "rtc_audio_source.h"
 #include "rtc_audio_track.h"
+#include "rtc_types.h"
 #ifdef RTC_DESKTOP_DEVICE
 #include "rtc_desktop_device.h"
 #endif
@@ -42,8 +41,7 @@ class RTCPeerConnectionFactory : public RefCountInterface {
       const string audio_source_label) = 0;
 
   virtual scoped_refptr<RTCVideoSource> CreateVideoSource(
-      scoped_refptr<RTCVideoCapturer> capturer,
-      const string video_source_label,
+      scoped_refptr<RTCVideoCapturer> capturer, const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) = 0;
 #ifdef RTC_DESKTOP_DEVICE
   virtual scoped_refptr<RTCVideoSource> CreateDesktopSource(
@@ -52,12 +50,10 @@ class RTCPeerConnectionFactory : public RefCountInterface {
       scoped_refptr<RTCMediaConstraints> constraints) = 0;
 #endif
   virtual scoped_refptr<RTCAudioTrack> CreateAudioTrack(
-      scoped_refptr<RTCAudioSource> source,
-      const string track_id) = 0;
+      scoped_refptr<RTCAudioSource> source, const string track_id) = 0;
 
   virtual scoped_refptr<RTCVideoTrack> CreateVideoTrack(
-      scoped_refptr<RTCVideoSource> source,
-      const string track_id) = 0;
+      scoped_refptr<RTCVideoSource> source, const string track_id) = 0;
 
   virtual scoped_refptr<RTCMediaStream> CreateStream(
       const string stream_id) = 0;

--- a/include/rtc_rtp_capabilities.h
+++ b/include/rtc_rtp_capabilities.h
@@ -3,7 +3,6 @@
 
 #include "base/refcount.h"
 #include "base/scoped_ref_ptr.h"
-
 #include "rtc_rtp_parameters.h"
 #include "rtc_types.h"
 

--- a/include/rtc_rtp_parameters.h
+++ b/include/rtc_rtp_parameters.h
@@ -3,7 +3,6 @@
 
 #include "base/refcount.h"
 #include "base/scoped_ref_ptr.h"
-
 #include "rtc_types.h"
 
 namespace libwebrtc {

--- a/include/rtc_rtp_receiver.h
+++ b/include/rtc_rtp_receiver.h
@@ -3,7 +3,6 @@
 
 #include "base/refcount.h"
 #include "base/scoped_ref_ptr.h"
-
 #include "rtc_rtp_parameters.h"
 #include "rtc_types.h"
 

--- a/include/rtc_rtp_sender.h
+++ b/include/rtc_rtp_sender.h
@@ -3,7 +3,6 @@
 
 #include "base/refcount.h"
 #include "base/scoped_ref_ptr.h"
-
 #include "rtc_rtp_parameters.h"
 #include "rtc_types.h"
 

--- a/include/rtc_rtp_transceiver.h
+++ b/include/rtc_rtp_transceiver.h
@@ -13,8 +13,7 @@ namespace libwebrtc {
 class RTCRtpTransceiverInit : public RefCountInterface {
  public:
   LIB_WEBRTC_API static scoped_refptr<RTCRtpTransceiverInit> Create(
-      RTCRtpTransceiverDirection direction,
-      const vector<string> stream_ids,
+      RTCRtpTransceiverDirection direction, const vector<string> stream_ids,
       const vector<scoped_refptr<RTCRtpEncodingParameters>> encodings);
 
   virtual RTCRtpTransceiverDirection direction() = 0;

--- a/include/rtc_session_description.h
+++ b/include/rtc_session_description.h
@@ -9,8 +9,8 @@ class RTCSessionDescription : public RefCountInterface {
  public:
   enum SdpType { kOffer = 0, kPrAnswer, kAnswer };
 
-  static LIB_WEBRTC_API scoped_refptr<RTCSessionDescription>
-  Create(const string type, const string sdp, SdpParseError* error);
+  static LIB_WEBRTC_API scoped_refptr<RTCSessionDescription> Create(
+      const string type, const string sdp, SdpParseError* error);
 
  public:
   virtual const string sdp() const = 0;

--- a/include/rtc_video_device.h
+++ b/include/rtc_video_device.h
@@ -20,8 +20,7 @@ class RTCVideoDevice : public RefCountInterface {
  public:
   virtual uint32_t NumberOfDevices() = 0;
 
-  virtual int32_t GetDeviceName(uint32_t deviceNumber,
-                                char* deviceNameUTF8,
+  virtual int32_t GetDeviceName(uint32_t deviceNumber, char* deviceNameUTF8,
                                 uint32_t deviceNameLength,
                                 char* deviceUniqueIdUTF8,
                                 uint32_t deviceUniqueIdUTF8Length,
@@ -29,8 +28,7 @@ class RTCVideoDevice : public RefCountInterface {
                                 uint32_t productUniqueIdUTF8Length = 0) = 0;
 
   virtual scoped_refptr<RTCVideoCapturer> Create(const char* name,
-                                                 uint32_t index,
-                                                 size_t width,
+                                                 uint32_t index, size_t width,
                                                  size_t height,
                                                  size_t target_fps) = 0;
 

--- a/include/rtc_video_frame.h
+++ b/include/rtc_video_frame.h
@@ -17,18 +17,12 @@ class RTCVideoFrame : public RefCountInterface {
   };
 
  public:
-  LIB_WEBRTC_API static scoped_refptr<RTCVideoFrame>
-  Create(int width, int height, const uint8_t* buffer, int length);
+  LIB_WEBRTC_API static scoped_refptr<RTCVideoFrame> Create(
+      int width, int height, const uint8_t* buffer, int length);
 
   LIB_WEBRTC_API static scoped_refptr<RTCVideoFrame> Create(
-      int width,
-      int height,
-      const uint8_t* data_y,
-      int stride_y,
-      const uint8_t* data_u,
-      int stride_u,
-      const uint8_t* data_v,
-      int stride_v);
+      int width, int height, const uint8_t* data_y, int stride_y,
+      const uint8_t* data_u, int stride_u, const uint8_t* data_v, int stride_v);
 
   virtual scoped_refptr<RTCVideoFrame> Copy() = 0;
 
@@ -50,11 +44,8 @@ class RTCVideoFrame : public RefCountInterface {
   virtual int StrideU() const = 0;
   virtual int StrideV() const = 0;
 
-  virtual int ConvertToARGB(Type type,
-                            uint8_t* dst_argb,
-                            int dst_stride_argb,
-                            int dest_width,
-                            int dest_height) = 0;
+  virtual int ConvertToARGB(Type type, uint8_t* dst_argb, int dst_stride_argb,
+                            int dest_width, int dest_height) = 0;
 
  protected:
   virtual ~RTCVideoFrame() {}

--- a/include/rtc_video_track.h
+++ b/include/rtc_video_track.h
@@ -1,9 +1,8 @@
 #ifndef LIB_WEBRTC_RTC_VIDEO_TRACK_HXX
 #define LIB_WEBRTC_RTC_VIDEO_TRACK_HXX
 
-#include "rtc_types.h"
-
 #include "rtc_media_track.h"
+#include "rtc_types.h"
 #include "rtc_video_frame.h"
 #include "rtc_video_renderer.h"
 

--- a/src/base/portable.cc
+++ b/src/base/portable.cc
@@ -2,14 +2,10 @@
 
 namespace portable {
 
-static int strncpy_safe(char* dest,
-                        size_t numberOfElements,
-                        const char* src,
+static int strncpy_safe(char* dest, size_t numberOfElements, const char* src,
                         size_t count) {
-  if (!count)
-    return 0;
-  if (!dest || !src || !numberOfElements)
-    return -1;
+  if (!count) return 0;
+  if (!dest || !src || !numberOfElements) return -1;
   size_t end = count != _TRUNCATE && count < numberOfElements
                    ? count
                    : numberOfElements - 1;
@@ -25,9 +21,7 @@ static int strncpy_safe(char* dest,
   return -1;
 }
 
-string::string() : m_dynamic(0), m_length(0) {
-  m_buf[0] = 0;
-}
+string::string() : m_dynamic(0), m_length(0) { m_buf[0] = 0; }
 
 void string::init(const char* str, size_t len) {
   m_length = len;
@@ -41,12 +35,10 @@ void string::init(const char* str, size_t len) {
 }
 
 void string::destroy() {
-  if (m_dynamic != 0)
-    delete[] m_dynamic;
+  if (m_dynamic != 0) delete[] m_dynamic;
 }
 
 string ::~string() {
-  if (m_dynamic != 0)
-    delete[] m_dynamic;
+  if (m_dynamic != 0) delete[] m_dynamic;
 }
 }  // namespace portable

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -1,4 +1,5 @@
 #include "helper.h"
+
 #include "rtc_base/helpers.h"
 
 namespace libwebrtc {
@@ -8,8 +9,6 @@ namespace libwebrtc {
  *
  * @return A string representation of a random UUID.
  */
-string Helper::CreateRandomUuid() {
-  return rtc::CreateRandomUuid();
-}
+string Helper::CreateRandomUuid() { return rtc::CreateRandomUuid(); }
 
 }  // namespace libwebrtc

--- a/src/internal/desktop_capturer.h
+++ b/src/internal/desktop_capturer.h
@@ -8,25 +8,23 @@
 #ifdef WEBRTC_WIN
 #include "modules/desktop_capture/win/window_capture_utils.h"
 #endif
-#include "modules/video_capture/video_capture.h"
-#include "modules/video_capture/video_capture_factory.h"
-
 #include "api/scoped_refptr.h"
 #include "api/video/i420_buffer.h"
 #include "api/video/video_frame.h"
 #include "api/video/video_source_interface.h"
+#include "include/base/refcount.h"
 #include "media/base/video_adapter.h"
 #include "media/base/video_broadcaster.h"
+#include "modules/video_capture/video_capture.h"
+#include "modules/video_capture/video_capture_factory.h"
 #include "pc/video_track_source.h"
 #include "rtc_base/thread.h"
 #include "rtc_desktop_device.h"
+#include "rtc_types.h"
 #include "src/internal/vcm_capturer.h"
 #include "src/internal/video_capturer.h"
-#include "third_party/libyuv/include/libyuv.h"
-
-#include "include/base/refcount.h"
-#include "rtc_types.h"
 #include "src/rtc_desktop_capturer_impl.h"
+#include "third_party/libyuv/include/libyuv.h"
 
 namespace libwebrtc {
 

--- a/src/internal/jpeg_util.cc
+++ b/src/internal/jpeg_util.cc
@@ -15,10 +15,8 @@ extern "C" {
 namespace libwebrtc {
 
 std::vector<unsigned char> EncodeRGBToJpeg(const unsigned char* rgb_buf,
-                                           int width,
-                                           int height,
-                                           int color_planes,
-                                           int quality) {
+                                           int width, int height,
+                                           int color_planes, int quality) {
   std::vector<unsigned char> result;
   unsigned char* out_buffer = NULL;
   unsigned long out_size = 0;

--- a/src/internal/jpeg_util.h
+++ b/src/internal/jpeg_util.h
@@ -2,14 +2,13 @@
 #define INTERNAL_JPEG_UTIL_HXX
 
 #include <inttypes.h>
+
 #include <vector>
 
 namespace libwebrtc {
 // Encodes the given RGB data into a JPEG image.
-std::vector<unsigned char> EncodeRGBToJpeg(const unsigned char* data,
-                                           int width,
-                                           int height,
-                                           int color_planes,
+std::vector<unsigned char> EncodeRGBToJpeg(const unsigned char* data, int width,
+                                           int height, int color_planes,
                                            int quality);
 }  // namespace libwebrtc
 

--- a/src/internal/vcm_capturer.cc
+++ b/src/internal/vcm_capturer.cc
@@ -11,6 +11,7 @@
 #include "src/internal/vcm_capturer.h"
 
 #include <stdint.h>
+
 #include <memory>
 
 #include "modules/video_capture/video_capture_factory.h"
@@ -23,9 +24,7 @@ namespace internal {
 VcmCapturer::VcmCapturer(rtc::Thread* worker_thread)
     : vcm_(nullptr), worker_thread_(worker_thread) {}
 
-bool VcmCapturer::Init(size_t width,
-                       size_t height,
-                       size_t target_fps,
+bool VcmCapturer::Init(size_t width, size_t height, size_t target_fps,
                        size_t capture_device_index) {
   std::unique_ptr<VideoCaptureModule::DeviceInfo> device_info(
       VideoCaptureFactory::CreateDeviceInfo());
@@ -59,8 +58,7 @@ bool VcmCapturer::Init(size_t width,
 }
 
 std::shared_ptr<VcmCapturer> VcmCapturer::Create(rtc::Thread* worker_thread,
-                                                 size_t width,
-                                                 size_t height,
+                                                 size_t width, size_t height,
                                                  size_t target_fps,
                                                  size_t capture_device_index) {
   std::shared_ptr<VcmCapturer> vcm_capturer(
@@ -88,9 +86,7 @@ bool VcmCapturer::StartCapture() {
 
 bool VcmCapturer::CaptureStarted() {
   return vcm_ != nullptr &&
-         worker_thread_->BlockingCall([&] {
-    return vcm_->CaptureStarted();
-  });
+         worker_thread_->BlockingCall([&] { return vcm_->CaptureStarted(); });
 }
 
 void VcmCapturer::StopCapture() {
@@ -102,17 +98,14 @@ void VcmCapturer::StopCapture() {
 }
 
 void VcmCapturer::Destroy() {
-  if (!vcm_)
-    return;
+  if (!vcm_) return;
 
   vcm_->DeRegisterCaptureDataCallback();
 
   StopCapture();
 }
 
-VcmCapturer::~VcmCapturer() {
-  Destroy();
-}
+VcmCapturer::~VcmCapturer() { Destroy(); }
 
 void VcmCapturer::OnFrame(const VideoFrame& frame) {
   VideoCapturer::OnFrame(frame);

--- a/src/internal/vcm_capturer.h
+++ b/src/internal/vcm_capturer.h
@@ -25,8 +25,7 @@ class VcmCapturer : public VideoCapturer,
                     public rtc::VideoSinkInterface<VideoFrame> {
  public:
   static std::shared_ptr<VcmCapturer> Create(rtc::Thread* worker_thread,
-                                             size_t width,
-                                             size_t height,
+                                             size_t width, size_t height,
                                              size_t target_fps,
                                              size_t capture_device_index);
   VcmCapturer(rtc::Thread* worker_thread);
@@ -42,9 +41,7 @@ class VcmCapturer : public VideoCapturer,
   void OnFrame(const VideoFrame& frame) override;
 
  private:
-  bool Init(size_t width,
-            size_t height,
-            size_t target_fps,
+  bool Init(size_t width, size_t height, size_t target_fps,
             size_t capture_device_index);
   void Destroy();
 

--- a/src/libwebrtc.cc
+++ b/src/libwebrtc.cc
@@ -3,7 +3,6 @@
 #include "api/scoped_refptr.h"
 #include "rtc_base/ssl_adapter.h"
 #include "rtc_base/thread.h"
-
 #include "rtc_peerconnection_factory_impl.h"
 
 namespace libwebrtc {

--- a/src/rtc_audio_device_impl.cc
+++ b/src/rtc_audio_device_impl.cc
@@ -1,4 +1,5 @@
 #include "rtc_audio_device_impl.h"
+
 #include "rtc_base/logging.h"
 
 namespace libwebrtc {
@@ -106,8 +107,7 @@ int32_t AudioDeviceImpl::OnDeviceChange(OnDeviceChangeCallback listener) {
 }
 
 void AudioDeviceImpl::OnDevicesUpdated() {
-  if (listener_)
-    listener_();
+  if (listener_) listener_();
 }
 
 }  // namespace libwebrtc

--- a/src/rtc_audio_device_impl.h
+++ b/src/rtc_audio_device_impl.h
@@ -21,12 +21,10 @@ class AudioDeviceImpl : public RTCAudioDevice, public webrtc::AudioDeviceSink {
 
   int16_t RecordingDevices() override;
 
-  int32_t PlayoutDeviceName(uint16_t index,
-                            char name[kAdmMaxDeviceNameSize],
+  int32_t PlayoutDeviceName(uint16_t index, char name[kAdmMaxDeviceNameSize],
                             char guid[kAdmMaxGuidSize]) override;
 
-  int32_t RecordingDeviceName(uint16_t index,
-                              char name[kAdmMaxDeviceNameSize],
+  int32_t RecordingDeviceName(uint16_t index, char name[kAdmMaxDeviceNameSize],
                               char guid[kAdmMaxGuidSize]) override;
 
   int32_t SetPlayoutDevice(uint16_t index) override;

--- a/src/rtc_audio_source_impl.h
+++ b/src/rtc_audio_source_impl.h
@@ -1,8 +1,6 @@
 #ifndef LIB_WEBRTC_AUDIO_SOURCE_IMPL_HXX
 #define LIB_WEBRTC_AUDIO_SOURCE_IMPL_HXX
 
-#include "rtc_audio_source.h"
-
 #include "api/media_stream_interface.h"
 #include "api/peer_connection_interface.h"
 #include "common_audio/resampler/include/push_resampler.h"
@@ -10,6 +8,7 @@
 #include "media/engine/webrtc_video_engine.h"
 #include "media/engine/webrtc_voice_engine.h"
 #include "pc/media_session.h"
+#include "rtc_audio_source.h"
 #include "rtc_base/logging.h"
 #include "rtc_base/synchronization/mutex.h"
 

--- a/src/rtc_audio_track_impl.h
+++ b/src/rtc_audio_track_impl.h
@@ -1,8 +1,6 @@
 #ifndef LIB_WEBRTC_AUDIO_TRACK_IMPL_HXX
 #define LIB_WEBRTC_AUDIO_TRACK_IMPL_HXX
 
-#include "rtc_audio_track.h"
-
 #include "api/media_stream_interface.h"
 #include "api/peer_connection_interface.h"
 #include "common_audio/resampler/include/push_resampler.h"
@@ -10,6 +8,7 @@
 #include "media/engine/webrtc_video_engine.h"
 #include "media/engine/webrtc_voice_engine.h"
 #include "pc/media_session.h"
+#include "rtc_audio_track.h"
 #include "rtc_base/logging.h"
 #include "rtc_base/synchronization/mutex.h"
 

--- a/src/rtc_data_channel_impl.cc
+++ b/src/rtc_data_channel_impl.cc
@@ -13,8 +13,7 @@ RTCDataChannelImpl::~RTCDataChannelImpl() {
   rtc_data_channel_->UnregisterObserver();
 }
 
-void RTCDataChannelImpl::Send(const uint8_t* data,
-                              uint32_t size,
+void RTCDataChannelImpl::Send(const uint8_t* data, uint32_t size,
                               bool binary /*= false*/) {
   rtc::CopyOnWriteBuffer copyOnWriteBuffer(data, size);
   webrtc::DataBuffer buffer(copyOnWriteBuffer, binary);
@@ -36,13 +35,9 @@ void RTCDataChannelImpl::UnregisterObserver() {
   observer_ = nullptr;
 }
 
-const string RTCDataChannelImpl::label() const {
-  return label_;
-}
+const string RTCDataChannelImpl::label() const { return label_; }
 
-int RTCDataChannelImpl::id() const {
-  return rtc_data_channel_->id();
-}
+int RTCDataChannelImpl::id() const { return rtc_data_channel_->id(); }
 
 void RTCDataChannelImpl::OnStateChange() {
   webrtc::DataChannelInterface::DataState state = rtc_data_channel_->state();
@@ -63,13 +58,10 @@ void RTCDataChannelImpl::OnStateChange() {
       break;
   }
   webrtc::MutexLock(crit_sect_.get());
-  if (observer_)
-    observer_->OnStateChange(state_);
+  if (observer_) observer_->OnStateChange(state_);
 }
 
-RTCDataChannelState RTCDataChannelImpl::state() {
-  return state_;
-}
+RTCDataChannelState RTCDataChannelImpl::state() { return state_; }
 
 void RTCDataChannelImpl::OnMessage(const webrtc::DataBuffer& buffer) {
   if (observer_)

--- a/src/rtc_data_channel_impl.h
+++ b/src/rtc_data_channel_impl.h
@@ -14,8 +14,7 @@ class RTCDataChannelImpl : public RTCDataChannel,
   RTCDataChannelImpl(
       rtc::scoped_refptr<webrtc::DataChannelInterface> rtc_data_channel);
 
-  virtual void Send(const uint8_t* data,
-                    uint32_t size,
+  virtual void Send(const uint8_t* data, uint32_t size,
                     bool binary = false) override;
 
   virtual void Close() override;

--- a/src/rtc_desktop_capturer_impl.cc
+++ b/src/rtc_desktop_capturer_impl.cc
@@ -28,10 +28,8 @@ namespace libwebrtc {
 enum { kCaptureDelay = 33, kCaptureMessageId = 1000 };
 
 RTCDesktopCapturerImpl::RTCDesktopCapturerImpl(
-    DesktopType type,
-    webrtc::DesktopCapturer::SourceId source_id,
-    rtc::Thread* signaling_thread,
-    scoped_refptr<MediaSource> source)
+    DesktopType type, webrtc::DesktopCapturer::SourceId source_id,
+    rtc::Thread* signaling_thread, scoped_refptr<MediaSource> source)
     : thread_(rtc::Thread::Create()),
       source_id_(source_id),
       signaling_thread_(signaling_thread),
@@ -49,7 +47,7 @@ RTCDesktopCapturerImpl::RTCDesktopCapturerImpl(
     options_.set_allow_pipewire(true);
   }
 #endif
- thread_->BlockingCall([this, type] {
+  thread_->BlockingCall([this, type] {
     if (type == kScreen) {
       capturer_ = std::make_unique<webrtc::DesktopAndCursorComposer>(
           webrtc::DesktopCapturer::CreateScreenCapturer(options_), options_);
@@ -65,11 +63,8 @@ RTCDesktopCapturerImpl::~RTCDesktopCapturerImpl() {
   capturer_.reset();
 }
 
-RTCDesktopCapturerImpl::CaptureState RTCDesktopCapturerImpl::Start(uint32_t fps,
-                                                                   uint32_t x,
-                                                                   uint32_t y,
-                                                                   uint32_t w,
-                                                                   uint32_t h) {
+RTCDesktopCapturerImpl::CaptureState RTCDesktopCapturerImpl::Start(
+    uint32_t fps, uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
   x_ = x;
   y_ = y;
   w_ = w;
@@ -83,7 +78,7 @@ RTCDesktopCapturerImpl::CaptureState RTCDesktopCapturerImpl::Start(uint32_t fps,
 
 RTCDesktopCapturerImpl::CaptureState RTCDesktopCapturerImpl::Start(
     uint32_t fps) {
-  if(capture_state_  == CS_RUNNING) {
+  if (capture_state_ == CS_RUNNING) {
     return capture_state_;
   }
 
@@ -147,7 +142,8 @@ void RTCDesktopCapturerImpl::OnCaptureResult(
   if (result != result_) {
     if (result == webrtc::DesktopCapturer::Result::ERROR_PERMANENT) {
       if (observer_) {
-        signaling_thread_->BlockingCall([&, this]() { observer_->OnError(this); });
+        signaling_thread_->BlockingCall(
+            [&, this]() { observer_->OnError(this); });
       }
       capture_state_ = CS_FAILED;
       return;
@@ -156,7 +152,8 @@ void RTCDesktopCapturerImpl::OnCaptureResult(
     if (result == webrtc::DesktopCapturer::Result::ERROR_TEMPORARY) {
       result_ = result;
       if (observer_) {
-        signaling_thread_->BlockingCall([&, this]() { observer_->OnPaused(this); });
+        signaling_thread_->BlockingCall(
+            [&, this]() { observer_->OnPaused(this); });
       }
       return;
     }
@@ -164,7 +161,8 @@ void RTCDesktopCapturerImpl::OnCaptureResult(
     if (result == webrtc::DesktopCapturer::Result::SUCCESS) {
       result_ = result;
       if (observer_) {
-        signaling_thread_->BlockingCall([&, this]() { observer_->OnStart(this); });
+        signaling_thread_->BlockingCall(
+            [&, this]() { observer_->OnStart(this); });
       }
     }
   }
@@ -212,16 +210,13 @@ void RTCDesktopCapturerImpl::OnCaptureResult(
 #endif
 }
 
-
 void RTCDesktopCapturerImpl::CaptureFrame() {
   RTC_DCHECK_RUN_ON(thread_.get());
   if (capture_state_ == CS_RUNNING) {
     capturer_->CaptureFrame();
     thread_->PostDelayedHighPrecisionTask(
-      [this]() {
-        CaptureFrame();
-      },
-      webrtc::TimeDelta::Millis(capture_delay_));
+        [this]() { CaptureFrame(); },
+        webrtc::TimeDelta::Millis(capture_delay_));
   }
 }
 

--- a/src/rtc_desktop_capturer_impl.h
+++ b/src/rtc_desktop_capturer_impl.h
@@ -17,11 +17,10 @@
 #ifndef LIBWEBRTC_RTC_DESKTOP_CAPTURER_IMPL_HXX
 #define LIBWEBRTC_RTC_DESKTOP_CAPTURER_IMPL_HXX
 
-#include "include/rtc_desktop_capturer.h"
-#include "include/rtc_types.h"
-
 #include "api/video/i420_buffer.h"
 #include "api/video/video_frame.h"
+#include "include/rtc_desktop_capturer.h"
+#include "include/rtc_types.h"
 #include "modules/desktop_capture/desktop_and_cursor_composer.h"
 #include "modules/desktop_capture/desktop_capture_options.h"
 #include "modules/desktop_capture/desktop_capturer.h"
@@ -50,10 +49,7 @@ class RTCDesktopCapturerImpl : public RTCDesktopCapturer,
   void DeRegisterDesktopCapturerObserver() override { observer_ = nullptr; }
   CaptureState Start(uint32_t fps) override;
 
-  CaptureState Start(uint32_t fps,
-                     uint32_t x,
-                     uint32_t y,
-                     uint32_t w,
+  CaptureState Start(uint32_t fps, uint32_t x, uint32_t y, uint32_t w,
                      uint32_t h) override;
 
   void Stop() override;

--- a/src/rtc_desktop_device_impl.cc
+++ b/src/rtc_desktop_device_impl.cc
@@ -1,4 +1,5 @@
 #include "rtc_desktop_device_impl.h"
+
 #include "rtc_base/thread.h"
 #include "rtc_desktop_capturer.h"
 #include "rtc_desktop_media_list.h"

--- a/src/rtc_desktop_device_impl.h
+++ b/src/rtc_desktop_device_impl.h
@@ -10,7 +10,6 @@
 #endif
 #include "rtc_base/thread.h"
 #include "rtc_desktop_device.h"
-
 #include "rtc_desktop_media_list_impl.h"
 
 namespace libwebrtc {

--- a/src/rtc_desktop_media_list_impl.cc
+++ b/src/rtc_desktop_media_list_impl.cc
@@ -15,6 +15,7 @@
  */
 
 #include "rtc_desktop_media_list_impl.h"
+
 #include "internal/jpeg_util.h"
 #include "rtc_base/checks.h"
 #include "third_party/libyuv/include/libyuv.h"
@@ -56,9 +57,7 @@ RTCDesktopMediaListImpl::RTCDesktopMediaListImpl(DesktopType type,
   });
 }
 
-RTCDesktopMediaListImpl::~RTCDesktopMediaListImpl() {
-  thread_->Stop();
-}
+RTCDesktopMediaListImpl::~RTCDesktopMediaListImpl() { thread_->Stop(); }
 
 int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
                                                   bool get_thumbnail) {
@@ -66,18 +65,16 @@ int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
     for (auto source : sources_) {
       if (observer_) {
         auto source_ptr = source.get();
-        signaling_thread_->BlockingCall([&, source_ptr]() {
-          observer_->OnMediaSourceRemoved(source_ptr);
-        });
+        signaling_thread_->BlockingCall(
+            [&, source_ptr]() { observer_->OnMediaSourceRemoved(source_ptr); });
       }
     }
     sources_.clear();
   }
 
   webrtc::DesktopCapturer::SourceList new_sources;
-  thread_->BlockingCall([this, &new_sources] {
-    capturer_->GetSourceList(&new_sources);
-  });
+  thread_->BlockingCall(
+      [this, &new_sources] { capturer_->GetSourceList(&new_sources); });
 
   typedef std::set<webrtc::DesktopCapturer::SourceId> SourceSet;
   SourceSet new_source_set;
@@ -92,9 +89,8 @@ int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
     if (new_source_set.find(sources_[i]->source_id()) == new_source_set.end()) {
       if (observer_) {
         auto source = (*(sources_.begin() + i)).get();
-        signaling_thread_->BlockingCall([&, source]() {
-          observer_->OnMediaSourceRemoved(source);
-        });
+        signaling_thread_->BlockingCall(
+            [&, source]() { observer_->OnMediaSourceRemoved(source); });
       }
       sources_.erase(sources_.begin() + i);
       --i;
@@ -113,9 +109,8 @@ int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
         sources_.insert(sources_.begin() + i, source);
         GetThumbnail(source, true);
         if (observer_) {
-          signaling_thread_->BlockingCall([&, source]() {
-            observer_->OnMediaSourceAdded(source);
-          });
+          signaling_thread_->BlockingCall(
+              [&, source]() { observer_->OnMediaSourceAdded(source); });
         }
       }
     }
@@ -131,8 +126,7 @@ int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
       // of |sources_|, because entries before |pos| should have been sorted.
       size_t old_pos = pos + 1;
       for (; old_pos < sources_.size(); ++old_pos) {
-        if (sources_[old_pos]->source_id() == new_sources[pos].id)
-          break;
+        if (sources_[old_pos]->source_id() == new_sources[pos].id) break;
       }
       RTC_DCHECK(sources_[old_pos]->source_id() == new_sources[pos].id);
 
@@ -147,9 +141,8 @@ int32_t RTCDesktopMediaListImpl::UpdateSourceList(bool force_reload,
       sources_[pos]->source.title = new_sources[pos].title;
       if (observer_) {
         auto source = sources_[pos].get();
-        signaling_thread_->BlockingCall([&, source]() {
-          observer_->OnMediaSourceNameChanged(source);
-        });
+        signaling_thread_->BlockingCall(
+            [&, source]() { observer_->OnMediaSourceNameChanged(source); });
       }
     }
     ++pos;
@@ -184,9 +177,7 @@ bool RTCDesktopMediaListImpl::GetThumbnail(scoped_refptr<MediaSource> source,
   return true;
 }
 
-int RTCDesktopMediaListImpl::GetSourceCount() const {
-  return sources_.size();
-}
+int RTCDesktopMediaListImpl::GetSourceCount() const { return sources_.size(); }
 
 scoped_refptr<MediaSource> RTCDesktopMediaListImpl::GetSource(int index) {
   return sources_[index];

--- a/src/rtc_desktop_media_list_impl.h
+++ b/src/rtc_desktop_media_list_impl.h
@@ -23,7 +23,6 @@
 #include "modules/desktop_capture/desktop_capturer.h"
 #include "modules/desktop_capture/desktop_frame.h"
 #include "rtc_base/thread.h"
-
 #include "rtc_desktop_capturer_impl.h"
 #include "rtc_desktop_media_list.h"
 
@@ -34,8 +33,7 @@ class RTCDesktopMediaListImpl;
 class MediaSourceImpl : public MediaSource {
  public:
   MediaSourceImpl(RTCDesktopMediaListImpl* mediaList,
-                  webrtc::DesktopCapturer::Source src,
-                  DesktopType type)
+                  webrtc::DesktopCapturer::Source src, DesktopType type)
       : source(src), mediaList_(mediaList), type_(type) {}
   virtual ~MediaSourceImpl() {}
 
@@ -96,6 +94,7 @@ class RTCDesktopMediaListImpl : public RTCDesktopMediaList {
 
   bool GetThumbnail(scoped_refptr<MediaSource> source,
                     bool notify = false) override;
+
  private:
   class CallbackProxy : public webrtc::DesktopCapturer::Callback {
    public:
@@ -110,8 +109,7 @@ class RTCDesktopMediaListImpl : public RTCDesktopMediaList {
    private:
     void OnCaptureResult(webrtc::DesktopCapturer::Result result,
                          std::unique_ptr<webrtc::DesktopFrame> frame) override {
-      if (on_capture_result_)
-        on_capture_result_(result, std::move(frame));
+      if (on_capture_result_) on_capture_result_(result, std::move(frame));
     }
     std::function<void(webrtc::DesktopCapturer::Result result,
                        std::unique_ptr<webrtc::DesktopFrame> frame)>

--- a/src/rtc_dtls_transport_impl.cc
+++ b/src/rtc_dtls_transport_impl.cc
@@ -1,4 +1,5 @@
 #include "rtc_dtls_transport_impl.h"
+
 #include "base/refcountedobject.h"
 
 // #include "rtc_ice_transport_impl.h"

--- a/src/rtc_dtmf_sender_impl.cc
+++ b/src/rtc_dtmf_sender_impl.cc
@@ -11,24 +11,19 @@ RTCDtmfSenderImpl::dtmf_sender() {
   return dtmf_sender_;
 }
 
-bool RTCDtmfSenderImpl::InsertDtmf(const string tones,
-                                   int duration,
+bool RTCDtmfSenderImpl::InsertDtmf(const string tones, int duration,
                                    int inter_tone_gap) {
   return dtmf_sender_->InsertDtmf(to_std_string(tones), duration,
                                   inter_tone_gap);
 }
 
-bool RTCDtmfSenderImpl::InsertDtmf(const string tones,
-                                   int duration,
-                                   int inter_tone_gap,
-                                   int comma_delay) {
+bool RTCDtmfSenderImpl::InsertDtmf(const string tones, int duration,
+                                   int inter_tone_gap, int comma_delay) {
   return dtmf_sender_->InsertDtmf(to_std_string(tones), duration,
                                   inter_tone_gap, comma_delay);
 }
 
-const string RTCDtmfSenderImpl::tones() const {
-  return dtmf_sender_->tones();
-}
+const string RTCDtmfSenderImpl::tones() const { return dtmf_sender_->tones(); }
 
 void RTCDtmfSenderImpl::OnToneChange(const std::string& tone,
                                      const std::string& tone_buffer) {
@@ -57,9 +52,7 @@ bool RTCDtmfSenderImpl::CanInsertDtmf() {
   return dtmf_sender_->CanInsertDtmf();
 }
 
-int RTCDtmfSenderImpl::duration() const {
-  return dtmf_sender_->duration();
-}
+int RTCDtmfSenderImpl::duration() const { return dtmf_sender_->duration(); }
 
 int RTCDtmfSenderImpl::inter_tone_gap() const {
   return dtmf_sender_->inter_tone_gap();

--- a/src/rtc_dtmf_sender_impl.h
+++ b/src/rtc_dtmf_sender_impl.h
@@ -22,12 +22,9 @@ class RTCDtmfSenderImpl : public RTCDtmfSender,
   virtual int duration() const override;
   virtual int inter_tone_gap() const override;
   virtual int comma_delay() const override;
-  virtual bool InsertDtmf(const string tones,
-                          int duration,
+  virtual bool InsertDtmf(const string tones, int duration,
                           int inter_tone_gap) override;
-  virtual bool InsertDtmf(const string tones,
-                          int duration,
-                          int inter_tone_gap,
+  virtual bool InsertDtmf(const string tones, int duration, int inter_tone_gap,
                           int comma_delay) override;
   virtual const string tones() const override;
 

--- a/src/rtc_frame_cryptor_impl.cc
+++ b/src/rtc_frame_cryptor_impl.cc
@@ -1,27 +1,24 @@
 #include "rtc_frame_cryptor_impl.h"
+
 #include "rtc_peerconnection_factory_impl.h"
 
 namespace libwebrtc {
 
 scoped_refptr<RTCFrameCryptor> FrameCryptorFactory::frameCryptorFromRtpSender(
     scoped_refptr<RTCPeerConnectionFactory> factory,
-    const string participant_id,
-    scoped_refptr<RTCRtpSender> sender,
-    Algorithm algorithm,
-    scoped_refptr<KeyProvider> key_provider) {
-  return new RefCountedObject<RTCFrameCryptorImpl>(factory, participant_id, algorithm,
-                                                   key_provider, sender);
+    const string participant_id, scoped_refptr<RTCRtpSender> sender,
+    Algorithm algorithm, scoped_refptr<KeyProvider> key_provider) {
+  return new RefCountedObject<RTCFrameCryptorImpl>(
+      factory, participant_id, algorithm, key_provider, sender);
 }
 
 /// Create a frame cyrptor from a [RTCRtpReceiver].
 scoped_refptr<RTCFrameCryptor> FrameCryptorFactory::frameCryptorFromRtpReceiver(
     scoped_refptr<RTCPeerConnectionFactory> factory,
-    const string participant_id,
-    scoped_refptr<RTCRtpReceiver> receiver,
-    Algorithm algorithm,
-    scoped_refptr<KeyProvider> key_provider) {
-  return new RefCountedObject<RTCFrameCryptorImpl>(factory, participant_id, algorithm,
-                                                   key_provider, receiver);
+    const string participant_id, scoped_refptr<RTCRtpReceiver> receiver,
+    Algorithm algorithm, scoped_refptr<KeyProvider> key_provider) {
+  return new RefCountedObject<RTCFrameCryptorImpl>(
+      factory, participant_id, algorithm, key_provider, receiver);
 }
 
 webrtc::FrameCryptorTransformer::Algorithm AlgorithmToFrameCryptorAlgorithm(
@@ -38,10 +35,8 @@ webrtc::FrameCryptorTransformer::Algorithm AlgorithmToFrameCryptorAlgorithm(
 
 RTCFrameCryptorImpl::RTCFrameCryptorImpl(
     scoped_refptr<RTCPeerConnectionFactory> factory,
-    const string participant_id,
-    Algorithm algorithm,
-    scoped_refptr<KeyProvider> key_provider,
-    scoped_refptr<RTCRtpSender> sender)
+    const string participant_id, Algorithm algorithm,
+    scoped_refptr<KeyProvider> key_provider, scoped_refptr<RTCRtpSender> sender)
     : participant_id_(participant_id),
       enabled_(false),
       key_index_(0),
@@ -56,9 +51,9 @@ RTCFrameCryptorImpl::RTCFrameCryptorImpl(
           ? webrtc::FrameCryptorTransformer::MediaType::kAudioFrame
           : webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
   e2ee_transformer_ = rtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
-      new webrtc::FrameCryptorTransformer(factoryImpl->signaling_thread(),
-          participant_id_.std_string(), mediaType,
-          AlgorithmToFrameCryptorAlgorithm(algorithm),
+      new webrtc::FrameCryptorTransformer(
+          factoryImpl->signaling_thread(), participant_id_.std_string(),
+          mediaType, AlgorithmToFrameCryptorAlgorithm(algorithm),
           keyImpl->rtc_key_provider()));
   e2ee_transformer_->RegisterFrameCryptorTransformerObserver(observer_);
   impl->rtc_rtp_sender()->SetEncoderToPacketizerFrameTransformer(
@@ -68,8 +63,7 @@ RTCFrameCryptorImpl::RTCFrameCryptorImpl(
 
 RTCFrameCryptorImpl::RTCFrameCryptorImpl(
     scoped_refptr<RTCPeerConnectionFactory> factory,
-    const string participant_id,
-    Algorithm algorithm,
+    const string participant_id, Algorithm algorithm,
     scoped_refptr<KeyProvider> key_provider,
     scoped_refptr<RTCRtpReceiver> receiver)
     : participant_id_(participant_id),
@@ -77,7 +71,8 @@ RTCFrameCryptorImpl::RTCFrameCryptorImpl(
       key_index_(0),
       key_provider_(key_provider),
       receiver_(receiver),
-      observer_(rtc::make_ref_counted<libwebrtc::RTCFrameCryptorObserverAdapter>()) {
+      observer_(
+          rtc::make_ref_counted<libwebrtc::RTCFrameCryptorObserverAdapter>()) {
   auto factoryImpl = static_cast<RTCPeerConnectionFactoryImpl*>(factory.get());
   auto keyImpl = static_cast<DefaultKeyProviderImpl*>(key_provider.get());
   RTCRtpReceiverImpl* impl = static_cast<RTCRtpReceiverImpl*>(receiver.get());
@@ -86,9 +81,9 @@ RTCFrameCryptorImpl::RTCFrameCryptorImpl(
           ? webrtc::FrameCryptorTransformer::MediaType::kAudioFrame
           : webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
   e2ee_transformer_ = rtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
-      new webrtc::FrameCryptorTransformer(factoryImpl->signaling_thread(),
-          participant_id_.std_string(), mediaType,
-          AlgorithmToFrameCryptorAlgorithm(algorithm),
+      new webrtc::FrameCryptorTransformer(
+          factoryImpl->signaling_thread(), participant_id_.std_string(),
+          mediaType, AlgorithmToFrameCryptorAlgorithm(algorithm),
           keyImpl->rtc_key_provider()));
   e2ee_transformer_->RegisterFrameCryptorTransformerObserver(observer_);
   impl->rtp_receiver()->SetDepacketizerToDecoderFrameTransformer(
@@ -105,7 +100,8 @@ bool RTCFrameCryptorImpl::SetEnabled(bool enabled) {
   return true;
 }
 
-void RTCFrameCryptorImpl::RegisterRTCFrameCryptorObserver(scoped_refptr<RTCFrameCryptorObserver> observer) {
+void RTCFrameCryptorImpl::RegisterRTCFrameCryptorObserver(
+    scoped_refptr<RTCFrameCryptorObserver> observer) {
   webrtc::MutexLock lock(&mutex_);
   observer_->RegisterObserver(observer);
 }
@@ -117,8 +113,7 @@ void RTCFrameCryptorImpl::DeRegisterRTCFrameCryptorObserver() {
 }
 
 void RTCFrameCryptorObserverAdapter::OnFrameCryptionStateChanged(
-    const std::string participant_id,
-    webrtc::FrameCryptionState error) {
+    const std::string participant_id, webrtc::FrameCryptionState error) {
   {
     RTCFrameCryptionState state = RTCFrameCryptionState::kNew;
     switch (error) {

--- a/src/rtc_frame_cryptor_impl.h
+++ b/src/rtc_frame_cryptor_impl.h
@@ -1,13 +1,12 @@
 #ifndef LIB_RTC_FRAME_CYRPTOR_IMPL_H_
 #define LIB_RTC_FRAME_CYRPTOR_IMPL_H_
 
-#include "rtc_frame_cryptor.h"
-#include "rtc_rtp_receiver_impl.h"
-#include "rtc_rtp_sender_impl.h"
-
 #include "api/crypto/frame_crypto_transformer.h"
 #include "api/rtp_receiver_interface.h"
 #include "api/rtp_sender_interface.h"
+#include "rtc_frame_cryptor.h"
+#include "rtc_rtp_receiver_impl.h"
+#include "rtc_rtp_sender_impl.h"
 
 namespace libwebrtc {
 class DefaultKeyProviderImpl : public KeyProvider {
@@ -38,8 +37,7 @@ class DefaultKeyProviderImpl : public KeyProvider {
   }
 
   /// Set the key at the given index.
-  bool SetKey(const string participant_id,
-              int index,
+  bool SetKey(const string participant_id, int index,
               vector<uint8_t> key) override {
     return impl_->SetKey(participant_id.std_string(), index, key.std_vector());
   }
@@ -64,9 +62,9 @@ class DefaultKeyProviderImpl : public KeyProvider {
   rtc::scoped_refptr<webrtc::DefaultKeyProviderImpl> impl_;
 };
 
-
-class RTCFrameCryptorObserverAdapter : public webrtc::FrameCryptorTransformerObserver {
-  public:
+class RTCFrameCryptorObserverAdapter
+    : public webrtc::FrameCryptorTransformerObserver {
+ public:
   RTCFrameCryptorObserverAdapter() = default;
   void OnFrameCryptionStateChanged(const std::string participant_id,
                                    webrtc::FrameCryptionState error) override;
@@ -81,22 +79,20 @@ class RTCFrameCryptorObserverAdapter : public webrtc::FrameCryptorTransformerObs
     observer_ = nullptr;
   }
 
-  private:
-    mutable webrtc::Mutex mutex_;
-    scoped_refptr<RTCFrameCryptorObserver> observer_;
+ private:
+  mutable webrtc::Mutex mutex_;
+  scoped_refptr<RTCFrameCryptorObserver> observer_;
 };
 
 class RTCFrameCryptorImpl : public RTCFrameCryptor {
  public:
   RTCFrameCryptorImpl(scoped_refptr<RTCPeerConnectionFactory> factory,
-                     const string participant_id,
-                      Algorithm algorithm,
+                      const string participant_id, Algorithm algorithm,
                       scoped_refptr<KeyProvider> key_provider,
                       scoped_refptr<RTCRtpSender> sender);
 
-  RTCFrameCryptorImpl(scoped_refptr<RTCPeerConnectionFactory> factory, 
-                      const string participant_id,
-                      Algorithm algorithm,
+  RTCFrameCryptorImpl(scoped_refptr<RTCPeerConnectionFactory> factory,
+                      const string participant_id, Algorithm algorithm,
                       scoped_refptr<KeyProvider> key_provider,
                       scoped_refptr<RTCRtpReceiver> receiver);
   ~RTCFrameCryptorImpl();

--- a/src/rtc_ice_candidate_impl.cc
+++ b/src/rtc_ice_candidate_impl.cc
@@ -12,10 +12,12 @@ scoped_refptr<RTCIceCandidate> RTCIceCandidate::Create(const string sdp,
                                  to_std_string(sdp), &sdp_error));
   error->description = sdp_error.description;
   error->line = sdp_error.line;
-  scoped_refptr<RTCIceCandidate> candidate = scoped_refptr<RTCIceCandidateImpl>(
-      new RefCountedObject<RTCIceCandidateImpl>(std::move(rtc_candidate)));
+  if (rtc_candidate) {
+    return scoped_refptr<RTCIceCandidateImpl>(
+        new RefCountedObject<RTCIceCandidateImpl>(std::move(rtc_candidate)));
+  }
 
-  return candidate;
+  return nullptr;
 }
 
 RTCIceCandidateImpl::RTCIceCandidateImpl(

--- a/src/rtc_ice_candidate_impl.cc
+++ b/src/rtc_ice_candidate_impl.cc
@@ -31,9 +31,7 @@ const string RTCIceCandidateImpl::candidate() const {
   return sdp_;
 }
 
-const string RTCIceCandidateImpl::sdp_mid() const {
-  return sdp_mid_;
-}
+const string RTCIceCandidateImpl::sdp_mid() const { return sdp_mid_; }
 
 int RTCIceCandidateImpl::sdp_mline_index() const {
   return candidate_->sdp_mline_index();

--- a/src/rtc_media_stream_impl.cc
+++ b/src/rtc_media_stream_impl.cc
@@ -57,8 +57,7 @@ bool MediaStreamImpl::RemoveTrack(scoped_refptr<RTCAudioTrack> track) {
   AudioTrackImpl* track_impl = static_cast<AudioTrackImpl*>(track.get());
   if (rtc_media_stream_->RemoveTrack(track_impl->rtc_track())) {
     auto it = std::find(audio_tracks_.begin(), audio_tracks_.end(), track);
-    if (it != audio_tracks_.end())
-      audio_tracks_.erase(it);
+    if (it != audio_tracks_.end()) audio_tracks_.erase(it);
     return true;
   }
   return false;
@@ -68,8 +67,7 @@ bool MediaStreamImpl::RemoveTrack(scoped_refptr<RTCVideoTrack> track) {
   VideoTrackImpl* track_impl = static_cast<VideoTrackImpl*>(track.get());
   if (rtc_media_stream_->RemoveTrack(track_impl->rtc_track())) {
     auto it = std::find(video_tracks_.begin(), video_tracks_.end(), track);
-    if (it != video_tracks_.end())
-      video_tracks_.erase(it);
+    if (it != video_tracks_.end()) video_tracks_.erase(it);
 
     return true;
   }
@@ -98,8 +96,7 @@ vector<scoped_refptr<RTCMediaTrack>> MediaStreamImpl::tracks() {
 scoped_refptr<RTCAudioTrack> MediaStreamImpl::FindAudioTrack(
     const string track_id) {
   for (auto track : audio_tracks_) {
-    if (track->id().std_string() == track_id.std_string())
-      return track;
+    if (track->id().std_string() == track_id.std_string()) return track;
   }
 
   return scoped_refptr<RTCAudioTrack>();
@@ -108,8 +105,7 @@ scoped_refptr<RTCAudioTrack> MediaStreamImpl::FindAudioTrack(
 scoped_refptr<RTCVideoTrack> MediaStreamImpl::FindVideoTrack(
     const string track_id) {
   for (auto track : video_tracks_) {
-    if (track->id().std_string() == track_id.std_string())
-      return track;
+    if (track->id().std_string() == track_id.std_string()) return track;
   }
 
   return scoped_refptr<RTCVideoTrack>();

--- a/src/rtc_media_stream_impl.h
+++ b/src/rtc_media_stream_impl.h
@@ -16,8 +16,7 @@ class WebRTCStatsCollectorCallback : public webrtc::RTCStatsCollectorCallback {
   ~WebRTCStatsCollectorCallback() {}
 
   static rtc::scoped_refptr<WebRTCStatsCollectorCallback> Create(
-      OnStatsCollectorSuccess success,
-      OnStatsCollectorFailure failure) {
+      OnStatsCollectorSuccess success, OnStatsCollectorFailure failure) {
     rtc::scoped_refptr<WebRTCStatsCollectorCallback> rtc_stats_observer =
         rtc::scoped_refptr<WebRTCStatsCollectorCallback>(
             new rtc::RefCountedObject<WebRTCStatsCollectorCallback>(success,

--- a/src/rtc_mediaconstraints_impl.h
+++ b/src/rtc_mediaconstraints_impl.h
@@ -2,7 +2,6 @@
 #define LIB_WEBRTC_RTC_MEDIA_CONSTRAINTS_IMPL_HXX
 
 #include "rtc_mediaconstraints.h"
-
 #include "sdk/media_constraints.h"
 
 namespace libwebrtc {

--- a/src/rtc_peerconnection_factory_impl.cc
+++ b/src/rtc_peerconnection_factory_impl.cc
@@ -1,11 +1,4 @@
 #include "rtc_peerconnection_factory_impl.h"
-#include "rtc_audio_source_impl.h"
-#include "rtc_media_stream_impl.h"
-#include "rtc_mediaconstraints_impl.h"
-#include "rtc_peerconnection_impl.h"
-#include "rtc_rtp_capabilities_impl.h"
-#include "rtc_video_device_impl.h"
-#include "rtc_video_source_impl.h"
 
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
@@ -14,6 +7,13 @@
 #include "api/video_codecs/builtin_video_decoder_factory.h"
 #include "api/video_codecs/builtin_video_encoder_factory.h"
 #include "modules/audio_device/audio_device_impl.h"
+#include "rtc_audio_source_impl.h"
+#include "rtc_media_stream_impl.h"
+#include "rtc_mediaconstraints_impl.h"
+#include "rtc_peerconnection_impl.h"
+#include "rtc_rtp_capabilities_impl.h"
+#include "rtc_video_device_impl.h"
+#include "rtc_video_source_impl.h"
 #if defined(USE_INTEL_MEDIA_SDK)
 #include "src/win/mediacapabilities.h"
 #include "src/win/msdkvideodecoderfactory.h"
@@ -106,8 +106,7 @@ void RTCPeerConnectionFactoryImpl::CreateAudioDeviceModule_w() {
 }
 
 void RTCPeerConnectionFactoryImpl::DestroyAudioDeviceModule_w() {
-  if (audio_device_module_)
-    audio_device_module_ = nullptr;
+  if (audio_device_module_) audio_device_module_ = nullptr;
 }
 
 scoped_refptr<RTCPeerConnection> RTCPeerConnectionFactoryImpl::Create(
@@ -176,16 +175,14 @@ RTCPeerConnectionFactoryImpl::GetDesktopDevice() {
 #endif
 
 scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource(
-    scoped_refptr<RTCVideoCapturer> capturer,
-    const string video_source_label,
+    scoped_refptr<RTCVideoCapturer> capturer, const string video_source_label,
     scoped_refptr<RTCMediaConstraints> constraints) {
   if (rtc::Thread::Current() != signaling_thread_.get()) {
     scoped_refptr<RTCVideoSource> source = signaling_thread_->BlockingCall(
         [this, capturer, video_source_label, constraints] {
-              return CreateVideoSource_s(
-                  capturer, to_std_string(video_source_label).c_str(),
-                  constraints);
-         });
+          return CreateVideoSource_s(
+              capturer, to_std_string(video_source_label).c_str(), constraints);
+        });
     return source;
   }
 
@@ -194,8 +191,7 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource(
 }
 
 scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_s(
-    scoped_refptr<RTCVideoCapturer> capturer,
-    const char* video_source_label,
+    scoped_refptr<RTCVideoCapturer> capturer, const char* video_source_label,
     scoped_refptr<RTCMediaConstraints> constraints) {
   RTCVideoCapturerImpl* capturer_impl =
       static_cast<RTCVideoCapturerImpl*>(capturer.get());
@@ -212,16 +208,14 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_s(
 
 #ifdef RTC_DESKTOP_DEVICE
 scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateDesktopSource(
-    scoped_refptr<RTCDesktopCapturer> capturer,
-    const string video_source_label,
+    scoped_refptr<RTCDesktopCapturer> capturer, const string video_source_label,
     scoped_refptr<RTCMediaConstraints> constraints) {
   if (rtc::Thread::Current() != signaling_thread_.get()) {
     scoped_refptr<RTCVideoSource> source = signaling_thread_->BlockingCall(
         [this, capturer, video_source_label, constraints] {
-              return CreateDesktopSource_d(
-                  capturer, to_std_string(video_source_label).c_str(),
-                  constraints);
-            });
+          return CreateDesktopSource_d(
+              capturer, to_std_string(video_source_label).c_str(), constraints);
+        });
     return source;
   }
 
@@ -231,8 +225,7 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateDesktopSource(
 
 scoped_refptr<RTCVideoSource>
 RTCPeerConnectionFactoryImpl::CreateDesktopSource_d(
-    scoped_refptr<RTCDesktopCapturer> capturer,
-    const char* video_source_label,
+    scoped_refptr<RTCDesktopCapturer> capturer, const char* video_source_label,
     scoped_refptr<RTCMediaConstraints> constraints) {
   rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> rtc_source_track =
       rtc::scoped_refptr<webrtc::VideoTrackSourceInterface>(
@@ -258,8 +251,7 @@ scoped_refptr<RTCMediaStream> RTCPeerConnectionFactoryImpl::CreateStream(
 }
 
 scoped_refptr<RTCVideoTrack> RTCPeerConnectionFactoryImpl::CreateVideoTrack(
-    scoped_refptr<RTCVideoSource> source,
-    const string track_id) {
+    scoped_refptr<RTCVideoSource> source, const string track_id) {
   scoped_refptr<RTCVideoSourceImpl> source_adapter(
       static_cast<RTCVideoSourceImpl*>(source.get()));
   rtc::scoped_refptr<webrtc::VideoTrackInterface> rtc_video_track =
@@ -282,8 +274,7 @@ scoped_refptr<RTCVideoTrack> RTCPeerConnectionFactoryImpl::CreateVideoTrack(
 }
 
 scoped_refptr<RTCAudioTrack> RTCPeerConnectionFactoryImpl::CreateAudioTrack(
-    scoped_refptr<RTCAudioSource> source,
-    const string track_id) {
+    scoped_refptr<RTCAudioSource> source, const string track_id) {
   RTCAudioSourceImpl* source_impl =
       static_cast<RTCAudioSourceImpl*>(source.get());
 
@@ -302,8 +293,8 @@ RTCPeerConnectionFactoryImpl::GetRtpSenderCapabilities(
   if (rtc::Thread::Current() != signaling_thread_.get()) {
     scoped_refptr<RTCRtpCapabilities> capabilities =
         signaling_thread_->BlockingCall([this, media_type] {
-              return GetRtpSenderCapabilities(media_type);
-            });
+          return GetRtpSenderCapabilities(media_type);
+        });
     return capabilities;
   }
 
@@ -330,8 +321,8 @@ RTCPeerConnectionFactoryImpl::GetRtpReceiverCapabilities(
   if (rtc::Thread::Current() != signaling_thread_.get()) {
     scoped_refptr<RTCRtpCapabilities> capabilities =
         signaling_thread_->BlockingCall([this, media_type] {
-              return GetRtpSenderCapabilities(media_type);
-            });
+          return GetRtpSenderCapabilities(media_type);
+        });
     return capabilities;
   }
   cricket::MediaType type = cricket::MediaType::MEDIA_TYPE_AUDIO;

--- a/src/rtc_peerconnection_factory_impl.h
+++ b/src/rtc_peerconnection_factory_impl.h
@@ -1,16 +1,16 @@
 #ifndef LIB_WEBRTC_MEDIA_SESSION_FACTORY_IMPL_HXX
 #define LIB_WEBRTC_MEDIA_SESSION_FACTORY_IMPL_HXX
 
-#include "rtc_audio_device_impl.h"
-#include "rtc_peerconnection.h"
-#include "rtc_peerconnection_factory.h"
-#include "rtc_video_device_impl.h"
-
 #include <memory>
+
 #include "api/media_stream_interface.h"
 #include "api/peer_connection_interface.h"
 #include "api/task_queue/task_queue_factory.h"
+#include "rtc_audio_device_impl.h"
 #include "rtc_base/thread.h"
+#include "rtc_peerconnection.h"
+#include "rtc_peerconnection_factory.h"
+#include "rtc_video_device_impl.h"
 
 #ifdef RTC_DESKTOP_DEVICE
 #include "rtc_desktop_capturer_impl.h"
@@ -44,8 +44,7 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
       const string audio_source_label) override;
 
   virtual scoped_refptr<RTCVideoSource> CreateVideoSource(
-      scoped_refptr<RTCVideoCapturer> capturer,
-      const string video_source_label,
+      scoped_refptr<RTCVideoCapturer> capturer, const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) override;
 #ifdef RTC_DESKTOP_DEVICE
   virtual scoped_refptr<RTCDesktopDevice> GetDesktopDevice() override;
@@ -55,12 +54,10 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
       scoped_refptr<RTCMediaConstraints> constraints) override;
 #endif
   virtual scoped_refptr<RTCAudioTrack> CreateAudioTrack(
-      scoped_refptr<RTCAudioSource> source,
-      const string track_id) override;
+      scoped_refptr<RTCAudioSource> source, const string track_id) override;
 
   virtual scoped_refptr<RTCVideoTrack> CreateVideoTrack(
-      scoped_refptr<RTCVideoSource> source,
-      const string track_id) override;
+      scoped_refptr<RTCVideoSource> source, const string track_id) override;
 
   virtual scoped_refptr<RTCMediaStream> CreateStream(
       const string stream_id) override;
@@ -76,9 +73,7 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
   scoped_refptr<RTCRtpCapabilities> GetRtpReceiverCapabilities(
       RTCMediaType media_type) override;
 
-  rtc::Thread* signaling_thread() {
-    return signaling_thread_.get();
-  }
+  rtc::Thread* signaling_thread() { return signaling_thread_.get(); }
 
  protected:
   void CreateAudioDeviceModule_w();
@@ -86,8 +81,7 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
   void DestroyAudioDeviceModule_w();
 
   scoped_refptr<RTCVideoSource> CreateVideoSource_s(
-      scoped_refptr<RTCVideoCapturer> capturer,
-      const char* video_source_label,
+      scoped_refptr<RTCVideoCapturer> capturer, const char* video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints);
 #ifdef RTC_DESKTOP_DEVICE
   scoped_refptr<RTCVideoSource> CreateDesktopSource_d(

--- a/src/rtc_peerconnection_impl.cc
+++ b/src/rtc_peerconnection_impl.cc
@@ -125,8 +125,7 @@ class SetSessionDescriptionObserverProxy
     : public webrtc::SetSessionDescriptionObserver {
  public:
   static SetSessionDescriptionObserverProxy* Create(
-      OnSetSdpSuccess success_callback,
-      OnSetSdpFailure failure_callback) {
+      OnSetSdpSuccess success_callback, OnSetSdpFailure failure_callback) {
     return new rtc::RefCountedObject<SetSessionDescriptionObserverProxy>(
         success_callback, failure_callback);
   }
@@ -277,8 +276,7 @@ void RTCPeerConnectionImpl::OnDataChannel(
   data_channel_ = scoped_refptr<RTCDataChannelImpl>(
       new RefCountedObject<RTCDataChannelImpl>(rtc_data_channel));
 
-  if (observer_)
-    observer_->OnDataChannel(data_channel_);
+  if (observer_) observer_->OnDataChannel(data_channel_);
 }
 
 void RTCPeerConnectionImpl::OnRenegotiationNeeded() {
@@ -307,24 +305,20 @@ void RTCPeerConnectionImpl::OnIceConnectionChange(
 
 void RTCPeerConnectionImpl::OnSignalingChange(
     webrtc::PeerConnectionInterface::SignalingState new_state) {
-  if (observer_)
-    observer_->OnSignalingState(signaling_state_map[new_state]);
+  if (observer_) observer_->OnSignalingState(signaling_state_map[new_state]);
 }
 
-void RTCPeerConnectionImpl::AddCandidate(const string mid,
-                                         int mid_mline_index,
+void RTCPeerConnectionImpl::AddCandidate(const string mid, int mid_mline_index,
                                          const string cand_sdp) {
   webrtc::SdpParseError error;
   webrtc::IceCandidateInterface* candidate = webrtc::CreateIceCandidate(
       to_std_string(mid), mid_mline_index, to_std_string(cand_sdp), &error);
-  if (candidate != nullptr)
-    rtc_peerconnection_->AddIceCandidate(candidate);
+  if (candidate != nullptr) rtc_peerconnection_->AddIceCandidate(candidate);
 }
 
 void RTCPeerConnectionImpl::OnIceCandidate(
     const webrtc::IceCandidateInterface* candidate) {
-  if (!rtc_peerconnection_)
-    return;
+  if (!rtc_peerconnection_) return;
 
 #if 0
     if (candidate->candidate().protocol() != "tcp")
@@ -404,7 +398,7 @@ bool RTCPeerConnectionImpl::Initialize() {
 
   offer_answer_options_.use_rtp_mux = configuration_.use_rtp_mux;
 
-  //config.disable_ipv6 = configuration_.disable_ipv6;
+  // config.disable_ipv6 = configuration_.disable_ipv6;
   config.disable_ipv6_on_wifi = configuration_.disable_ipv6_on_wifi;
   config.disable_link_local_networks =
       configuration_.disable_link_local_networks;
@@ -440,8 +434,7 @@ bool RTCPeerConnectionImpl::Initialize() {
 }
 
 scoped_refptr<RTCDataChannel> RTCPeerConnectionImpl::CreateDataChannel(
-    const string label,
-    RTCDataChannelInit* dataChannelDict) {
+    const string label, RTCDataChannelInit* dataChannelDict) {
   webrtc::DataChannelInit init;
   init.id = dataChannelDict->id;
   init.maxRetransmits = dataChannelDict->maxRetransmits;
@@ -559,8 +552,7 @@ void RTCPeerConnectionImpl::GetRemoteDescription(OnGetSdpSuccess success,
 }
 
 void RTCPeerConnectionImpl::CreateOffer(
-    OnSdpCreateSuccess success,
-    OnSdpCreateFailure failure,
+    OnSdpCreateSuccess success, OnSdpCreateFailure failure,
     scoped_refptr<RTCMediaConstraints> constraints) {
   if (!rtc_peerconnection_.get() || !rtc_peerconnection_factory_.get()) {
     webrtc::MutexLock cs(callback_crt_sec_.get());
@@ -584,8 +576,7 @@ void RTCPeerConnectionImpl::CreateOffer(
 }
 
 void RTCPeerConnectionImpl::CreateAnswer(
-    OnSdpCreateSuccess success,
-    OnSdpCreateFailure failure,
+    OnSdpCreateSuccess success, OnSdpCreateFailure failure,
     scoped_refptr<RTCMediaConstraints> constraints) {
   if (!rtc_peerconnection_.get() || !rtc_peerconnection_factory_.get()) {
     webrtc::MutexLock cs(callback_crt_sec_.get());
@@ -791,8 +782,7 @@ scoped_refptr<RTCRtpTransceiver> RTCPeerConnectionImpl::AddTransceiver(
 }
 
 scoped_refptr<RTCRtpTransceiver> RTCPeerConnectionImpl::AddTransceiver(
-    RTCMediaType media_type,
-    scoped_refptr<RTCRtpTransceiverInit> init) {
+    RTCMediaType media_type, scoped_refptr<RTCRtpTransceiverInit> init) {
   RTCRtpTransceiverInitImpl* initImpl =
       static_cast<RTCRtpTransceiverInitImpl*>(init.get());
   webrtc::RTCErrorOr<rtc::scoped_refptr<webrtc::RtpTransceiverInterface>>
@@ -812,8 +802,7 @@ scoped_refptr<RTCRtpTransceiver> RTCPeerConnectionImpl::AddTransceiver(
 }
 
 scoped_refptr<RTCRtpSender> RTCPeerConnectionImpl::AddTrack(
-    scoped_refptr<RTCMediaTrack> track,
-    vector<string> streamIds) {
+    scoped_refptr<RTCMediaTrack> track, vector<string> streamIds) {
   webrtc::RTCErrorOr<rtc::scoped_refptr<webrtc::RtpSenderInterface>> errorOr;
 
   std::vector<std::string> stream_ids;
@@ -908,20 +897,12 @@ void WebRTCStatsCollectorCallback::OnStatsDelivered(
 MediaRTCStatsImpl::MediaRTCStatsImpl(std::unique_ptr<webrtc::RTCStats> stats)
     : stats_(std::move(stats)) {}
 
-const string MediaRTCStatsImpl::id() {
-  return stats_->id();
-}
+const string MediaRTCStatsImpl::id() { return stats_->id(); }
 
-const string MediaRTCStatsImpl::type() {
-  return stats_->type();
-}
+const string MediaRTCStatsImpl::type() { return stats_->type(); }
 
-int64_t MediaRTCStatsImpl::timestamp_us() {
-  return stats_->timestamp().us();
-}
+int64_t MediaRTCStatsImpl::timestamp_us() { return stats_->timestamp().us(); }
 
-const string MediaRTCStatsImpl::ToJson() {
-  return stats_->ToJson();
-}
+const string MediaRTCStatsImpl::ToJson() { return stats_->ToJson(); }
 
 }  // namespace libwebrtc

--- a/src/rtc_peerconnection_impl.h
+++ b/src/rtc_peerconnection_impl.h
@@ -37,22 +37,18 @@ class RTCPeerConnectionImpl : public RTCPeerConnection,
   virtual bool Initialize();
 
   virtual void CreateOffer(
-      OnSdpCreateSuccess success,
-      OnSdpCreateFailure failure,
+      OnSdpCreateSuccess success, OnSdpCreateFailure failure,
       scoped_refptr<RTCMediaConstraints> constraints) override;
 
   virtual void CreateAnswer(
-      OnSdpCreateSuccess success,
-      OnSdpCreateFailure failure,
+      OnSdpCreateSuccess success, OnSdpCreateFailure failure,
       scoped_refptr<RTCMediaConstraints> constraints) override;
 
-  virtual void SetLocalDescription(const string sdp,
-                                   const string type,
+  virtual void SetLocalDescription(const string sdp, const string type,
                                    OnSetSdpSuccess success,
                                    OnSetSdpFailure failure) override;
 
-  virtual void SetRemoteDescription(const string sdp,
-                                    const string type,
+  virtual void SetRemoteDescription(const string sdp, const string type,
                                     OnSetSdpSuccess success,
                                     OnSetSdpFailure failure) override;
 
@@ -62,8 +58,7 @@ class RTCPeerConnectionImpl : public RTCPeerConnection,
   virtual void GetRemoteDescription(OnGetSdpSuccess success,
                                     OnGetSdpFailure failure) override;
 
-  virtual void AddCandidate(const string mid,
-                            int midx,
+  virtual void AddCandidate(const string mid, int midx,
                             const string candiate) override;
 
   virtual void RestartIce() override;
@@ -90,8 +85,7 @@ class RTCPeerConnectionImpl : public RTCPeerConnection,
       scoped_refptr<RTCRtpTransceiverInit> init) override;
 
   virtual scoped_refptr<RTCRtpSender> AddTrack(
-      scoped_refptr<RTCMediaTrack> track,
-      vector<string> streamIds) override;
+      scoped_refptr<RTCMediaTrack> track, vector<string> streamIds) override;
 
   virtual bool RemoveTrack(scoped_refptr<RTCRtpSender> render) override;
 
@@ -128,8 +122,7 @@ class RTCPeerConnectionImpl : public RTCPeerConnection,
   virtual RTCIceGatheringState ice_gathering_state() override;
 
   virtual scoped_refptr<RTCDataChannel> CreateDataChannel(
-      const string label,
-      RTCDataChannelInit* dataChannelDict) override;
+      const string label, RTCDataChannelInit* dataChannelDict) override;
 
   virtual bool GetStats(scoped_refptr<RTCRtpSender> sender,
                         OnStatsCollectorSuccess success,

--- a/src/rtc_rtp_parameters_impl.cc
+++ b/src/rtc_rtp_parameters_impl.cc
@@ -143,9 +143,7 @@ void RTCRtpParametersImpl::set_transaction_id(const string id) {
   rtp_parameters_.transaction_id = to_std_string(id);
 }
 
-const string RTCRtpParametersImpl::mid() {
-  return rtp_parameters_.mid;
-}
+const string RTCRtpParametersImpl::mid() { return rtp_parameters_.mid; }
 void RTCRtpParametersImpl::set_mid(const string mid) {
   rtp_parameters_.mid = to_std_string(mid);
 }
@@ -276,9 +274,7 @@ void RTCRtcpParametersImpl::set_ssrc(uint32_t value) {
   rtcp_parameters_.ssrc = value;
 }
 
-const string RTCRtcpParametersImpl::cname() {
-  return rtcp_parameters_.cname;
-}
+const string RTCRtcpParametersImpl::cname() { return rtcp_parameters_.cname; }
 void RTCRtcpParametersImpl::set_cname(const string cname) {
   rtcp_parameters_.cname = to_std_string(cname);
 }
@@ -291,9 +287,7 @@ void RTCRtcpParametersImpl::set_reduced_size(bool value) {
   rtcp_parameters_.reduced_size = value;
 }
 
-bool RTCRtcpParametersImpl::mux() {
-  return rtcp_parameters_.mux;
-}
+bool RTCRtcpParametersImpl::mux() { return rtcp_parameters_.mux; }
 void RTCRtcpParametersImpl::set_mux(bool value) {}
 bool RTCRtcpParametersImpl::operator==(
     scoped_refptr<RTCRtcpParameters> o) const {
@@ -317,25 +311,17 @@ bool RTCRtpExtensionImpl::operator==(scoped_refptr<RTCRtpExtension> o) const {
          static_cast<RTCRtpExtensionImpl*>(o.get())->rtp_extension();
 }
 
-const string RTCRtpExtensionImpl::uri() {
-  return rtp_extension_.uri;
-}
+const string RTCRtpExtensionImpl::uri() { return rtp_extension_.uri; }
 
 void RTCRtpExtensionImpl::set_uri(const string uri) {
   rtp_extension_.uri = to_std_string(uri);
 }
 
-int RTCRtpExtensionImpl::id() {
-  return rtp_extension_.id;
-}
+int RTCRtpExtensionImpl::id() { return rtp_extension_.id; }
 
-void RTCRtpExtensionImpl::set_id(int value) {
-  rtp_extension_.id = value;
-}
+void RTCRtpExtensionImpl::set_id(int value) { rtp_extension_.id = value; }
 
-bool RTCRtpExtensionImpl::encrypt() {
-  return rtp_extension_.encrypt;
-}
+bool RTCRtpExtensionImpl::encrypt() { return rtp_extension_.encrypt; }
 
 void RTCRtpExtensionImpl::set_encrypt(bool value) {
   rtp_extension_.encrypt = value;
@@ -398,21 +384,21 @@ void RTCRtpCodecParametersImpl::set_num_channels(int value) {
 }
 
 int RTCRtpCodecParametersImpl::max_ptime() {
-  //return rtp_codec_parameters_.max_ptime.value_or(0);
+  // return rtp_codec_parameters_.max_ptime.value_or(0);
   return 0;
 }
 
 void RTCRtpCodecParametersImpl::set_max_ptime(int value) {
-  //rtp_codec_parameters_.max_ptime = value;
+  // rtp_codec_parameters_.max_ptime = value;
 }
 
 int RTCRtpCodecParametersImpl::ptime() {
-  //return rtp_codec_parameters_.ptime.value_or(0);
+  // return rtp_codec_parameters_.ptime.value_or(0);
   return 0;
 }
 
 void RTCRtpCodecParametersImpl::set_ptime(int value) {
-  //rtp_codec_parameters_.ptime = value;
+  // rtp_codec_parameters_.ptime = value;
 }
 
 const vector<scoped_refptr<RTCRtcpFeedback>>

--- a/src/rtc_rtp_receiver_impl.cc
+++ b/src/rtc_rtp_receiver_impl.cc
@@ -69,9 +69,7 @@ RTCMediaType RTCRtpReceiverImpl::media_type() const {
   return static_cast<RTCMediaType>(rtp_receiver_->media_type());
 }
 
-const string RTCRtpReceiverImpl::id() const {
-  return rtp_receiver_->id();
-}
+const string RTCRtpReceiverImpl::id() const { return rtp_receiver_->id(); }
 scoped_refptr<RTCRtpParameters> RTCRtpReceiverImpl::parameters() const {
   return new RefCountedObject<RTCRtpParametersImpl>(
       rtp_receiver_->GetParameters());

--- a/src/rtc_rtp_sender_impl.cc
+++ b/src/rtc_rtp_sender_impl.cc
@@ -56,17 +56,13 @@ scoped_refptr<RTCDtlsTransport> RTCRtpSenderImpl::dtls_transport() const {
       rtp_sender_->dtls_transport());
 }
 
-uint32_t RTCRtpSenderImpl::ssrc() const {
-  return rtp_sender_->ssrc();
-}
+uint32_t RTCRtpSenderImpl::ssrc() const { return rtp_sender_->ssrc(); }
 
 RTCMediaType RTCRtpSenderImpl::media_type() const {
   return static_cast<RTCMediaType>(rtp_sender_->media_type());
 }
 
-const string RTCRtpSenderImpl::id() const {
-  return rtp_sender_->id();
-}
+const string RTCRtpSenderImpl::id() const { return rtp_sender_->id(); }
 
 const vector<string> RTCRtpSenderImpl::stream_ids() const {
   std::vector<string> vec;

--- a/src/rtc_rtp_transceiver_impl.cc
+++ b/src/rtc_rtp_transceiver_impl.cc
@@ -1,4 +1,5 @@
 #include "rtc_rtp_transceiver_impl.h"
+
 #include <src/rtc_rtp_capabilities_impl.h>
 #include <src/rtc_rtp_parameters_impl.h>
 #include <src/rtc_rtp_receiver_impl.h>
@@ -10,8 +11,7 @@ namespace libwebrtc {
 
 LIB_WEBRTC_API scoped_refptr<RTCRtpTransceiverInit>
 RTCRtpTransceiverInit::Create(
-    RTCRtpTransceiverDirection direction,
-    const vector<string> stream_ids,
+    RTCRtpTransceiverDirection direction, const vector<string> stream_ids,
     const vector<scoped_refptr<RTCRtpEncodingParameters>> encodings) {
   auto init = new RefCountedObject<RTCRtpTransceiverInitImpl>();
   init->set_direction(direction);
@@ -136,9 +136,7 @@ const string RTCRtpTransceiverImpl::StopStandard() {
   return val;
 }
 
-void RTCRtpTransceiverImpl::StopInternal() {
-  rtp_transceiver_->StopInternal();
-}
+void RTCRtpTransceiverImpl::StopInternal() { rtp_transceiver_->StopInternal(); }
 
 const string RTCRtpTransceiverImpl::mid() const {
   auto temp = rtp_transceiver_->mid();

--- a/src/rtc_session_description_impl.cc
+++ b/src/rtc_session_description_impl.cc
@@ -12,11 +12,13 @@ scoped_refptr<RTCSessionDescription> RTCSessionDescription::Create(
                                        &sdp_error));
   error->description = sdp_error.description;
   error->line = sdp_error.line;
-  scoped_refptr<RTCSessionDescriptionImpl> session_description =
-      scoped_refptr<RTCSessionDescriptionImpl>(
-          new RefCountedObject<RTCSessionDescriptionImpl>(
-              std::move(rtc_description)));
-  return session_description;
+  if (rtc_description) {
+    return scoped_refptr<RTCSessionDescriptionImpl>(
+        new RefCountedObject<RTCSessionDescriptionImpl>(
+            std::move(rtc_description)));
+  }
+
+  return nullptr;
 }
 
 RTCSessionDescriptionImpl::RTCSessionDescriptionImpl(

--- a/src/rtc_session_description_impl.cc
+++ b/src/rtc_session_description_impl.cc
@@ -3,9 +3,7 @@
 namespace libwebrtc {
 
 scoped_refptr<RTCSessionDescription> RTCSessionDescription::Create(
-    const string type,
-    const string sdp,
-    SdpParseError* error) {
+    const string type, const string sdp, SdpParseError* error) {
   webrtc::SdpParseError sdp_error;
   std::unique_ptr<webrtc::SessionDescriptionInterface> rtc_description(
       webrtc::CreateSessionDescription(to_std_string(type), to_std_string(sdp),

--- a/src/rtc_session_description_impl.h
+++ b/src/rtc_session_description_impl.h
@@ -1,9 +1,8 @@
 #ifndef LIB_WEBRTC_RTC_SESSION_DESCRIPTION_IMPL_HXX
 #define LIB_WEBRTC_RTC_SESSION_DESCRIPTION_IMPL_HXX
-#include "rtc_types.h"
-
 #include "api/jsep.h"
 #include "rtc_session_description.h"
+#include "rtc_types.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_device_impl.cc
+++ b/src/rtc_video_device_impl.cc
@@ -18,11 +18,8 @@ uint32_t RTCVideoDeviceImpl::NumberOfDevices() {
 }
 
 int32_t RTCVideoDeviceImpl::GetDeviceName(
-    uint32_t deviceNumber,
-    char* deviceNameUTF8,
-    uint32_t deviceNameLength,
-    char* deviceUniqueIdUTF8,
-    uint32_t deviceUniqueIdUTF8Length,
+    uint32_t deviceNumber, char* deviceNameUTF8, uint32_t deviceNameLength,
+    char* deviceUniqueIdUTF8, uint32_t deviceUniqueIdUTF8Length,
     char* productUniqueIdUTF8 /*= 0*/,
     uint32_t productUniqueIdUTF8Length /*= 0*/) {
   if (!device_info_) {
@@ -50,9 +47,9 @@ scoped_refptr<RTCVideoCapturer> RTCVideoDeviceImpl::Create(const char* name,
   }
 
   return signaling_thread_->BlockingCall([vcm] {
-        return scoped_refptr<RTCVideoCapturerImpl>(
-            new RefCountedObject<RTCVideoCapturerImpl>(vcm));
-      });
+    return scoped_refptr<RTCVideoCapturerImpl>(
+        new RefCountedObject<RTCVideoCapturerImpl>(vcm));
+  });
 }
 
 }  // namespace libwebrtc

--- a/src/rtc_video_device_impl.h
+++ b/src/rtc_video_device_impl.h
@@ -1,14 +1,13 @@
 #ifndef LIB_WEBRTC_VIDEO_DEVICE_IMPL_HXX
 #define LIB_WEBRTC_VIDEO_DEVICE_IMPL_HXX
 
-#include "rtc_video_device.h"
+#include <memory>
 
 #include "modules/video_capture/video_capture.h"
 #include "rtc_base/thread.h"
+#include "rtc_video_device.h"
 #include "src/internal/vcm_capturer.h"
 #include "src/internal/video_capturer.h"
-
-#include <memory>
 
 namespace libwebrtc {
 
@@ -30,8 +29,7 @@ class RTCVideoCapturerImpl : public RTCVideoCapturer {
   }
 
   void StopCapture() override {
-    if (video_capturer_ != nullptr)
-      video_capturer_->StopCapture();
+    if (video_capturer_ != nullptr) video_capturer_->StopCapture();
   }
 
  private:
@@ -45,18 +43,14 @@ class RTCVideoDeviceImpl : public RTCVideoDevice {
  public:
   uint32_t NumberOfDevices() override;
 
-  int32_t GetDeviceName(uint32_t deviceNumber,
-                        char* deviceNameUTF8,
-                        uint32_t deviceNameLength,
-                        char* deviceUniqueIdUTF8,
+  int32_t GetDeviceName(uint32_t deviceNumber, char* deviceNameUTF8,
+                        uint32_t deviceNameLength, char* deviceUniqueIdUTF8,
                         uint32_t deviceUniqueIdUTF8Length,
                         char* productUniqueIdUTF8 = 0,
                         uint32_t productUniqueIdUTF8Length = 0) override;
 
-  scoped_refptr<RTCVideoCapturer> Create(const char* name,
-                                         uint32_t index,
-                                         size_t width,
-                                         size_t height,
+  scoped_refptr<RTCVideoCapturer> Create(const char* name, uint32_t index,
+                                         size_t width, size_t height,
                                          size_t target_fps) override;
 
  private:

--- a/src/rtc_video_frame_impl.cc
+++ b/src/rtc_video_frame_impl.cc
@@ -25,13 +25,9 @@ scoped_refptr<RTCVideoFrame> VideoFrameBufferImpl::Copy() {
   return frame;
 }
 
-int VideoFrameBufferImpl::width() const {
-  return buffer_->width();
-}
+int VideoFrameBufferImpl::width() const { return buffer_->width(); }
 
-int VideoFrameBufferImpl::height() const {
-  return buffer_->height();
-}
+int VideoFrameBufferImpl::height() const { return buffer_->height(); }
 
 const uint8_t* VideoFrameBufferImpl::DataY() const {
   return buffer_->GetI420()->DataY();
@@ -57,10 +53,8 @@ int VideoFrameBufferImpl::StrideV() const {
   return buffer_->GetI420()->StrideV();
 }
 
-int VideoFrameBufferImpl::ConvertToARGB(Type type,
-                                        uint8_t* dst_buffer,
-                                        int dst_stride,
-                                        int dest_width,
+int VideoFrameBufferImpl::ConvertToARGB(Type type, uint8_t* dst_buffer,
+                                        int dst_stride, int dest_width,
                                         int dest_height) {
   rtc::scoped_refptr<webrtc::I420Buffer> i420 =
       webrtc::I420Buffer::Rotate(*buffer_.get(), rotation_);
@@ -117,8 +111,7 @@ libwebrtc::RTCVideoFrame::VideoRotation VideoFrameBufferImpl::rotation() {
   return RTCVideoFrame::kVideoRotation_0;
 }
 
-scoped_refptr<RTCVideoFrame> RTCVideoFrame::Create(int width,
-                                                   int height,
+scoped_refptr<RTCVideoFrame> RTCVideoFrame::Create(int width, int height,
                                                    const uint8_t* buffer,
                                                    int length) {
   int stride_y = width;
@@ -143,14 +136,9 @@ scoped_refptr<RTCVideoFrame> RTCVideoFrame::Create(int width,
   return frame;
 }
 
-scoped_refptr<RTCVideoFrame> RTCVideoFrame::Create(int width,
-                                                   int height,
-                                                   const uint8_t* data_y,
-                                                   int stride_y,
-                                                   const uint8_t* data_u,
-                                                   int stride_u,
-                                                   const uint8_t* data_v,
-                                                   int stride_v) {
+scoped_refptr<RTCVideoFrame> RTCVideoFrame::Create(
+    int width, int height, const uint8_t* data_y, int stride_y,
+    const uint8_t* data_u, int stride_u, const uint8_t* data_v, int stride_v) {
   rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = webrtc::I420Buffer::Copy(
       width, height, data_y, stride_y, data_u, stride_u, data_v, stride_v);
 

--- a/src/rtc_video_frame_impl.h
+++ b/src/rtc_video_frame_impl.h
@@ -1,12 +1,11 @@
 #ifndef LIB_WEBRTC_VIDEO_FRAME_IMPL_HXX
 #define LIB_WEBRTC_VIDEO_FRAME_IMPL_HXX
 
-#include "rtc_video_frame.h"
-
 #include "api/video/i420_buffer.h"
 #include "api/video/video_frame_buffer.h"
 #include "api/video/video_rotation.h"
 #include "common_video/include/video_frame_buffer.h"
+#include "rtc_video_frame.h"
 
 namespace libwebrtc {
 
@@ -37,11 +36,8 @@ class VideoFrameBufferImpl : public RTCVideoFrame {
 
   int StrideV() const override;
 
-  int ConvertToARGB(Type type,
-                    uint8_t* dst_argb,
-                    int dst_stride_argb,
-                    int dest_width,
-                    int dest_height) override;
+  int ConvertToARGB(Type type, uint8_t* dst_argb, int dst_stride_argb,
+                    int dest_width, int dest_height) override;
 
   rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer() { return buffer_; }
 

--- a/src/rtc_video_sink_adapter.cc
+++ b/src/rtc_video_sink_adapter.cc
@@ -1,8 +1,8 @@
 #include "rtc_video_sink_adapter.h"
-#include "rtc_video_frame_impl.h"
-#include "rtc_video_track.h"
 
 #include "rtc_base/logging.h"
+#include "rtc_video_frame_impl.h"
+#include "rtc_video_track.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_sink_adapter.h
+++ b/src/rtc_video_sink_adapter.h
@@ -1,12 +1,11 @@
 #ifndef LIB_WEBRTC_VIDEO_SINK_ADPTER_HXX
 #define LIB_WEBRTC_VIDEO_SINK_ADPTER_HXX
 
-#include "rtc_peerconnection.h"
-#include "rtc_video_frame.h"
-
 #include "api/media_stream_interface.h"
 #include "api/peer_connection_interface.h"
 #include "rtc_base/synchronization/mutex.h"
+#include "rtc_peerconnection.h"
+#include "rtc_video_frame.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_source_impl.cc
+++ b/src/rtc_video_source_impl.cc
@@ -1,8 +1,8 @@
 #include "rtc_video_source_impl.h"
-#include "rtc_video_frame_impl.h"
 
 #include "modules/video_capture/video_capture_factory.h"
 #include "rtc_base/logging.h"
+#include "rtc_video_frame_impl.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_source_impl.h
+++ b/src/rtc_video_source_impl.h
@@ -1,14 +1,13 @@
 #ifndef LIB_WEBRTC_VIDEO_SOURCE_IMPL_HXX
 #define LIB_WEBRTC_VIDEO_SOURCE_IMPL_HXX
 
+#include "api/media_stream_interface.h"
+#include "media/base/video_broadcaster.h"
+#include "media/base/video_source_base.h"
 #include "rtc_peerconnection_factory_impl.h"
 #include "rtc_video_frame.h"
 #include "rtc_video_source.h"
 #include "rtc_video_track.h"
-
-#include "api/media_stream_interface.h"
-#include "media/base/video_broadcaster.h"
-#include "media/base/video_source_base.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_track_impl.cc
+++ b/src/rtc_video_track_impl.cc
@@ -1,7 +1,7 @@
 #include "rtc_video_track_impl.h"
-#include "rtc_media_stream_impl.h"
 
 #include "rtc_base/logging.h"
+#include "rtc_media_stream_impl.h"
 
 namespace libwebrtc {
 

--- a/src/rtc_video_track_impl.h
+++ b/src/rtc_video_track_impl.h
@@ -1,13 +1,12 @@
 #ifndef LIB_WEBRTC_VIDEO_TRACK_IMPL_HXX
 #define LIB_WEBRTC_VIDEO_TRACK_IMPL_HXX
 
+#include "api/media_stream_interface.h"
+#include "modules/video_capture/video_capture_factory.h"
 #include "rtc_types.h"
 #include "rtc_video_sink_adapter.h"
 #include "rtc_video_source_impl.h"
 #include "rtc_video_track.h"
-
-#include "api/media_stream_interface.h"
-#include "modules/video_capture/video_capture_factory.h"
 
 namespace libwebrtc {
 

--- a/src/win/base_allocator.cc
+++ b/src/win/base_allocator.cc
@@ -38,7 +38,9 @@ https://software.intel.com/en-us/media-client-solutions-support.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "base_allocator.h"
+
 #include <assert.h>
+
 #include <algorithm>
 
 namespace owt {
@@ -55,33 +57,27 @@ MFXFrameAllocator::MFXFrameAllocator() {
 
 MFXFrameAllocator::~MFXFrameAllocator() {}
 
-mfxStatus MFXFrameAllocator::Alloc_(mfxHDL pthis,
-                                    mfxFrameAllocRequest* request,
+mfxStatus MFXFrameAllocator::Alloc_(mfxHDL pthis, mfxFrameAllocRequest* request,
                                     mfxFrameAllocResponse* response) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXFrameAllocator& self = *(MFXFrameAllocator*)pthis;
 
   return self.AllocFrames(request, response);
 }
 
-mfxStatus MFXFrameAllocator::Lock_(mfxHDL pthis,
-                                   mfxMemId mid,
+mfxStatus MFXFrameAllocator::Lock_(mfxHDL pthis, mfxMemId mid,
                                    mfxFrameData* ptr) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXFrameAllocator& self = *(MFXFrameAllocator*)pthis;
 
   return self.LockFrame(mid, ptr);
 }
 
-mfxStatus MFXFrameAllocator::Unlock_(mfxHDL pthis,
-                                     mfxMemId mid,
+mfxStatus MFXFrameAllocator::Unlock_(mfxHDL pthis, mfxMemId mid,
                                      mfxFrameData* ptr) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXFrameAllocator& self = *(MFXFrameAllocator*)pthis;
 
@@ -90,19 +86,16 @@ mfxStatus MFXFrameAllocator::Unlock_(mfxHDL pthis,
 
 mfxStatus MFXFrameAllocator::Free_(mfxHDL pthis,
                                    mfxFrameAllocResponse* response) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXFrameAllocator& self = *(MFXFrameAllocator*)pthis;
 
   return self.FreeFrames(response);
 }
 
-mfxStatus MFXFrameAllocator::GetHDL_(mfxHDL pthis,
-                                     mfxMemId mid,
+mfxStatus MFXFrameAllocator::GetHDL_(mfxHDL pthis, mfxMemId mid,
                                      mfxHDL* handle) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXFrameAllocator& self = *(MFXFrameAllocator*)pthis;
 
@@ -114,8 +107,7 @@ BaseFrameAllocator::BaseFrameAllocator() {}
 BaseFrameAllocator::~BaseFrameAllocator() {}
 
 mfxStatus BaseFrameAllocator::CheckRequestType(mfxFrameAllocRequest* request) {
-  if (0 == request)
-    return MFX_ERR_NULL_PTR;
+  if (0 == request) return MFX_ERR_NULL_PTR;
 
   // check that Media SDK component is specified in request
   if ((request->Type & MEMTYPE_FROM_MASK) != 0)
@@ -129,8 +121,7 @@ mfxStatus BaseFrameAllocator::AllocFrames(mfxFrameAllocRequest* request,
   if (0 == request || 0 == response || 0 == request->NumFrameSuggested)
     return MFX_ERR_MEMORY_ALLOC;
 
-  if (MFX_ERR_NONE != CheckRequestType(request))
-    return MFX_ERR_UNSUPPORTED;
+  if (MFX_ERR_NONE != CheckRequestType(request)) return MFX_ERR_UNSUPPORTED;
 
   mfxStatus sts = MFX_ERR_NONE;
 
@@ -190,8 +181,7 @@ mfxStatus BaseFrameAllocator::AllocFrames(mfxFrameAllocRequest* request,
 mfxStatus BaseFrameAllocator::FreeFrames(mfxFrameAllocResponse* response) {
   std::lock_guard<std::mutex> lock(mtx);
 
-  if (response == 0)
-    return MFX_ERR_INVALID_HANDLE;
+  if (response == 0) return MFX_ERR_INVALID_HANDLE;
 
   mfxStatus sts = MFX_ERR_NONE;
 
@@ -249,12 +239,9 @@ MFXBufferAllocator::MFXBufferAllocator() {
 
 MFXBufferAllocator::~MFXBufferAllocator() {}
 
-mfxStatus MFXBufferAllocator::Alloc_(mfxHDL pthis,
-                                     mfxU32 nbytes,
-                                     mfxU16 type,
+mfxStatus MFXBufferAllocator::Alloc_(mfxHDL pthis, mfxU32 nbytes, mfxU16 type,
                                      mfxMemId* mid) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXBufferAllocator& self = *(MFXBufferAllocator*)pthis;
 
@@ -262,8 +249,7 @@ mfxStatus MFXBufferAllocator::Alloc_(mfxHDL pthis,
 }
 
 mfxStatus MFXBufferAllocator::Lock_(mfxHDL pthis, mfxMemId mid, mfxU8** ptr) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXBufferAllocator& self = *(MFXBufferAllocator*)pthis;
 
@@ -271,8 +257,7 @@ mfxStatus MFXBufferAllocator::Lock_(mfxHDL pthis, mfxMemId mid, mfxU8** ptr) {
 }
 
 mfxStatus MFXBufferAllocator::Unlock_(mfxHDL pthis, mfxMemId mid) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXBufferAllocator& self = *(MFXBufferAllocator*)pthis;
 
@@ -280,8 +265,7 @@ mfxStatus MFXBufferAllocator::Unlock_(mfxHDL pthis, mfxMemId mid) {
 }
 
 mfxStatus MFXBufferAllocator::Free_(mfxHDL pthis, mfxMemId mid) {
-  if (0 == pthis)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (0 == pthis) return MFX_ERR_MEMORY_ALLOC;
 
   MFXBufferAllocator& self = *(MFXBufferAllocator*)pthis;
 

--- a/src/win/base_allocator.h
+++ b/src/win/base_allocator.h
@@ -41,9 +41,11 @@ https://software.intel.com/en-us/media-client-solutions-support.
 #define OWT_BASE_WIN_BASEALLOCATOR_H__
 
 #include <string.h>
+
 #include <functional>
 #include <list>
 #include <memory>
+
 #include "mfxvideo.h"
 #include "msdkcommon.h"
 
@@ -75,17 +77,13 @@ class MFXFrameAllocator : public mfxFrameAllocator {
   virtual mfxStatus FreeFrames(mfxFrameAllocResponse* response) = 0;
 
  private:
-  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis,
-                                    mfxFrameAllocRequest* request,
+  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis, mfxFrameAllocRequest* request,
                                     mfxFrameAllocResponse* response);
-  static mfxStatus MFX_CDECL Lock_(mfxHDL pthis,
-                                   mfxMemId mid,
+  static mfxStatus MFX_CDECL Lock_(mfxHDL pthis, mfxMemId mid,
                                    mfxFrameData* ptr);
-  static mfxStatus MFX_CDECL Unlock_(mfxHDL pthis,
-                                     mfxMemId mid,
+  static mfxStatus MFX_CDECL Unlock_(mfxHDL pthis, mfxMemId mid,
                                      mfxFrameData* ptr);
-  static mfxStatus MFX_CDECL GetHDL_(mfxHDL pthis,
-                                     mfxMemId mid,
+  static mfxStatus MFX_CDECL GetHDL_(mfxHDL pthis, mfxMemId mid,
                                      mfxHDL* handle);
   static mfxStatus MFX_CDECL Free_(mfxHDL pthis,
                                    mfxFrameAllocResponse* response);
@@ -136,10 +134,8 @@ class BaseFrameAllocator : public MFXFrameAllocator {
 
     // compare responses by actual frame size, alignment (w and h) is up to
     // application
-    UniqueResponse(const mfxFrameAllocResponse& response,
-                   mfxU16 width,
-                   mfxU16 height,
-                   mfxU16 type)
+    UniqueResponse(const mfxFrameAllocResponse& response, mfxU16 width,
+                   mfxU16 height, mfxU16 type)
         : mfxFrameAllocResponse(response),
           m_width(width),
           m_height(height),
@@ -182,8 +178,7 @@ class BaseFrameAllocator : public MFXFrameAllocator {
   std::list<UniqueResponse> m_ExtResponses;
 
   struct IsSame : public std::binary_function<mfxFrameAllocResponse,
-                                              mfxFrameAllocResponse,
-                                              bool> {
+                                              mfxFrameAllocResponse, bool> {
     bool operator()(const mfxFrameAllocResponse& l,
                     const mfxFrameAllocResponse& r) const {
       return r.mids != 0 && l.mids != 0 && r.mids[0] == l.mids[0] &&
@@ -240,9 +235,7 @@ class MFXBufferAllocator : public mfxBufferAllocator {
   virtual mfxStatus FreeBuffer(mfxMemId mid) = 0;
 
  private:
-  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis,
-                                    mfxU32 nbytes,
-                                    mfxU16 type,
+  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis, mfxU32 nbytes, mfxU16 type,
                                     mfxMemId* mid);
   static mfxStatus MFX_CDECL Lock_(mfxHDL pthis, mfxMemId mid, mfxU8** ptr);
   static mfxStatus MFX_CDECL Unlock_(mfxHDL pthis, mfxMemId mid);

--- a/src/win/codecutils.cc
+++ b/src/win/codecutils.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/codecutils.h"
+
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "absl/types/optional.h"

--- a/src/win/codecutils.h
+++ b/src/win/codecutils.h
@@ -6,6 +6,7 @@
 #define OWT_BASE_CODECUTILS_H_
 
 #include <vector>
+
 #include "api/video/video_codec_type.h"
 #include "api/video_codecs/sdp_video_format.h"
 

--- a/src/win/commontypes.h
+++ b/src/win/commontypes.h
@@ -64,8 +64,7 @@ struct AudioCodecParameters {
   /// Construct an instance of AudioCodecParameters with codec name/channel
   /// count and clock rate.
   AudioCodecParameters(const AudioCodec& codec_name,
-                       unsigned long channel_count,
-                       unsigned long clock_rate)
+                       unsigned long channel_count, unsigned long clock_rate)
       : name(codec_name),
         channel_count(channel_count),
         clock_rate(clock_rate) {}
@@ -136,8 +135,7 @@ struct VideoEncodingParameters {
       : codec(), max_bitrate(0), hardware_accelerated(false) {}
   /// Construct an instance of VideoEncodingParameters
   VideoEncodingParameters(const VideoCodecParameters& codec_param,
-                          unsigned long bitrate_bps,
-                          bool hw)
+                          unsigned long bitrate_bps, bool hw)
       : codec(codec_param),
         max_bitrate(bitrate_bps),
         hardware_accelerated(hw) {}
@@ -197,8 +195,7 @@ struct StreamSourceInfo {
 #endif
   {
   }
-  StreamSourceInfo(AudioSourceInfo audio_source,
-                   VideoSourceInfo video_source
+  StreamSourceInfo(AudioSourceInfo audio_source, VideoSourceInfo video_source
 #ifdef OWT_ENABLE_QUIC
                    ,
                    DataSourceInfo data_source

--- a/src/win/d3d11_allocator.h
+++ b/src/win/d3d11_allocator.h
@@ -46,9 +46,11 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 
 #include <d3d11.h>
 #include <windows.h>
+
 #include <limits>
 #include <map>
 #include <vector>
+
 #include "base_allocator.h"
 
 struct ID3D11VideoDevice;
@@ -167,15 +169,13 @@ class D3D11FrameAllocator : public BaseFrameAllocator {
 
     static bool isAllocated(TextureResource& that) { return that.bAlloc; }
     ID3D11Texture2D* GetTexture(mfxMemId id) {
-      if (outerMids.empty())
-        return NULL;
+      if (outerMids.empty()) return NULL;
 
       return textures[((uintptr_t)id - (uintptr_t)outerMids.front()) %
                       textures.size()];
     }
     UINT GetSubResource(mfxMemId id) {
-      if (outerMids.empty())
-        return NULL;
+      if (outerMids.empty()) return NULL;
 
       return (UINT)(((uintptr_t)id - (uintptr_t)outerMids.front()) /
                     textures.size());
@@ -219,8 +219,7 @@ class D3D11FrameAllocator : public BaseFrameAllocator {
     ID3D11Texture2D* GetTexture() const { return m_pTexture; }
     UINT GetSubResource() const { return m_subResource; }
     void Release() {
-      if (NULL != m_pTarget)
-        m_pTarget->Release();
+      if (NULL != m_pTarget) m_pTarget->Release();
     }
   };
 

--- a/src/win/d3d11_manager.h
+++ b/src/win/d3d11_manager.h
@@ -10,6 +10,7 @@
 #include <dxgi1_2.h>
 #include <mfapi.h>
 #include <mfobjects.h>
+
 #include "rtc_base/logging.h"
 #include "rtc_base/ref_count.h"
 

--- a/src/win/d3d_allocator.cc
+++ b/src/win/d3d_allocator.cc
@@ -118,8 +118,7 @@ D3DFrameAllocator::~D3DFrameAllocator() {
 mfxStatus D3DFrameAllocator::Init(mfxAllocatorParams* pParams) {
   D3DAllocatorParams* pd3dParams = 0;
   pd3dParams = static_cast<D3DAllocatorParams*>(pParams);
-  if (!pd3dParams)
-    return MFX_ERR_NOT_INITIALIZED;
+  if (!pd3dParams) return MFX_ERR_NOT_INITIALIZED;
 
   m_manager = pd3dParams->pManager;
   m_surfaceUsage = pd3dParams->surfaceUsage;
@@ -144,18 +143,15 @@ mfxStatus D3DFrameAllocator::Close() {
 }
 
 mfxStatus D3DFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData* ptr) {
-  if (!ptr || !mid)
-    return MFX_ERR_NULL_PTR;
+  if (!ptr || !mid) return MFX_ERR_NULL_PTR;
 
   mfxHDLPair* dxmid = (mfxHDLPair*)mid;
   IDirect3DSurface9* pSurface = static_cast<IDirect3DSurface9*>(dxmid->first);
-  if (pSurface == 0)
-    return MFX_ERR_INVALID_HANDLE;
+  if (pSurface == 0) return MFX_ERR_INVALID_HANDLE;
 
   D3DSURFACE_DESC desc;
   HRESULT hr = pSurface->GetDesc(&desc);
-  if (FAILED(hr))
-    return MFX_ERR_LOCK_MEMORY;
+  if (FAILED(hr)) return MFX_ERR_LOCK_MEMORY;
 
   if (desc.Format != D3DFMT_NV12 && desc.Format != D3DFMT_YV12 &&
       desc.Format != D3DFMT_YUY2 && desc.Format != D3DFMT_R8G8B8 &&
@@ -168,8 +164,7 @@ mfxStatus D3DFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData* ptr) {
   D3DLOCKED_RECT locked;
 
   hr = pSurface->LockRect(&locked, 0, D3DLOCK_NOSYSLOCK);
-  if (FAILED(hr))
-    return MFX_ERR_LOCK_MEMORY;
+  if (FAILED(hr)) return MFX_ERR_LOCK_MEMORY;
 
   switch ((DWORD)desc.Format) {
     case D3DFMT_NV12:
@@ -238,13 +233,11 @@ mfxStatus D3DFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData* ptr) {
 }
 
 mfxStatus D3DFrameAllocator::UnlockFrame(mfxMemId mid, mfxFrameData* ptr) {
-  if (!mid)
-    return MFX_ERR_NULL_PTR;
+  if (!mid) return MFX_ERR_NULL_PTR;
 
   mfxHDLPair* dxmid = (mfxHDLPair*)mid;
   IDirect3DSurface9* pSurface = static_cast<IDirect3DSurface9*>(dxmid->first);
-  if (pSurface == 0)
-    return MFX_ERR_INVALID_HANDLE;
+  if (pSurface == 0) return MFX_ERR_INVALID_HANDLE;
 
   pSurface->UnlockRect();
 
@@ -259,8 +252,7 @@ mfxStatus D3DFrameAllocator::UnlockFrame(mfxMemId mid, mfxFrameData* ptr) {
 }
 
 mfxStatus D3DFrameAllocator::GetFrameHDL(mfxMemId mid, mfxHDL* handle) {
-  if (!mid || !handle)
-    return MFX_ERR_NULL_PTR;
+  if (!mid || !handle) return MFX_ERR_NULL_PTR;
 
   mfxHDLPair* dxMid = (mfxHDLPair*)mid;
   *handle = dxMid->first;
@@ -269,8 +261,7 @@ mfxStatus D3DFrameAllocator::GetFrameHDL(mfxMemId mid, mfxHDL* handle) {
 
 mfxStatus D3DFrameAllocator::CheckRequestType(mfxFrameAllocRequest* request) {
   mfxStatus sts = BaseFrameAllocator::CheckRequestType(request);
-  if (MFX_ERR_NONE != sts)
-    return sts;
+  if (MFX_ERR_NONE != sts) return sts;
 
   if ((request->Type & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET |
                         MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET)) != 0)
@@ -280,8 +271,7 @@ mfxStatus D3DFrameAllocator::CheckRequestType(mfxFrameAllocRequest* request) {
 }
 
 mfxStatus D3DFrameAllocator::ReleaseResponse(mfxFrameAllocResponse* response) {
-  if (!response)
-    return MFX_ERR_NULL_PTR;
+  if (!response) return MFX_ERR_NULL_PTR;
 
   mfxStatus sts = MFX_ERR_NONE;
 
@@ -304,8 +294,7 @@ mfxStatus D3DFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
                                        mfxFrameAllocResponse* response) {
   HRESULT hr;
 
-  if (request->NumFrameSuggested == 0)
-    return MFX_ERR_UNKNOWN;
+  if (request->NumFrameSuggested == 0) return MFX_ERR_UNKNOWN;
 
   D3DFORMAT format = ConvertMfxFourccToD3dFormat(request->Info.FourCC);
 
@@ -327,35 +316,30 @@ mfxStatus D3DFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
   if (target == DXVA2_VideoProcessorRenderTarget) {
     if (!m_hProcessor) {
       hr = m_manager->OpenDeviceHandle(&m_hProcessor);
-      if (FAILED(hr))
-        return MFX_ERR_MEMORY_ALLOC;
+      if (FAILED(hr)) return MFX_ERR_MEMORY_ALLOC;
 
       hr = m_manager->GetVideoService(m_hProcessor,
                                       IID_IDirectXVideoProcessorService,
                                       (void**)&m_processorService);
-      if (FAILED(hr))
-        return MFX_ERR_MEMORY_ALLOC;
+      if (FAILED(hr)) return MFX_ERR_MEMORY_ALLOC;
     }
     videoService = m_processorService;
   } else {
     if (!m_hDecoder) {
       hr = m_manager->OpenDeviceHandle(&m_hDecoder);
-      if (FAILED(hr))
-        return MFX_ERR_MEMORY_ALLOC;
+      if (FAILED(hr)) return MFX_ERR_MEMORY_ALLOC;
 
       hr = m_manager->GetVideoService(m_hDecoder,
                                       IID_IDirectXVideoDecoderService,
                                       (void**)&m_decoderService);
-      if (FAILED(hr))
-        return MFX_ERR_MEMORY_ALLOC;
+      if (FAILED(hr)) return MFX_ERR_MEMORY_ALLOC;
     }
     videoService = m_decoderService;
   }
 
   mfxHDLPair** dxMidPtrs =
       (mfxHDLPair**)calloc(request->NumFrameSuggested, sizeof(mfxHDLPair*));
-  if (!dxMidPtrs)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (!dxMidPtrs) return MFX_ERR_MEMORY_ALLOC;
 
   for (int i = 0; i < request->NumFrameSuggested; i++) {
     dxMidPtrs[i] = (mfxHDLPair*)calloc(1, sizeof(mfxHDLPair));

--- a/src/win/d3d_allocator.h
+++ b/src/win/d3d_allocator.h
@@ -46,7 +46,9 @@ https://software.intel.com/en-us/media-client-solutions-support.
 #include <d3d9.h>
 #include <dxva2api.h>
 #include <initguid.h>
+
 #include <vector>
+
 #include "base_allocator.h"
 
 namespace owt {

--- a/src/win/d3dnativeframe.h
+++ b/src/win/d3dnativeframe.h
@@ -5,6 +5,7 @@
 #define OWT_BASE_WIN_D3DNATIVEFRAME_H
 #include <d3d9.h>
 #include <dxva2api.h>
+
 #include "common_video/include/video_frame_buffer.h"
 namespace owt {
 namespace base {

--- a/src/win/include/mfxaudio++.h
+++ b/src/win/include/mfxaudio++.h
@@ -93,8 +93,7 @@ class MFXAudioDECODE {
   virtual mfxStatus GetAudioParam(mfxAudioParam* par) {
     return MFXAudioDECODE_GetAudioParam(m_session, par);
   }
-  virtual mfxStatus DecodeFrameAsync(mfxBitstream* bs,
-                                     mfxAudioFrame* frame,
+  virtual mfxStatus DecodeFrameAsync(mfxBitstream* bs, mfxAudioFrame* frame,
                                      mfxSyncPoint* syncp) {
     return MFXAudioDECODE_DecodeFrameAsync(m_session, bs, frame, syncp);
   }

--- a/src/win/include/mfxaudio.h
+++ b/src/win/include/mfxaudio.h
@@ -38,10 +38,8 @@ MFXAudioCORE_SyncOperation(mfxSession session, mfxSyncPoint syncp, mfxU32 wait);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Query(mfxSession session,
                                                         mfxAudioParam* in,
                                                         mfxAudioParam* out);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioENCODE_QueryIOSize(mfxSession session,
-                           mfxAudioParam* par,
-                           mfxAudioAllocRequest* request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_QueryIOSize(
+    mfxSession session, mfxAudioParam* par, mfxAudioAllocRequest* request);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Init(mfxSession session,
                                                        mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Reset(mfxSession session,
@@ -50,35 +48,27 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Close(mfxSession session);
 MFX_DEPRECATED mfxStatus MFX_CDECL
 MFXAudioENCODE_GetAudioParam(mfxSession session, mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioENCODE_EncodeFrameAsync(mfxSession session,
-                                mfxAudioFrame* frame,
-                                mfxBitstream* bs,
-                                mfxSyncPoint* syncp);
+MFXAudioENCODE_EncodeFrameAsync(mfxSession session, mfxAudioFrame* frame,
+                                mfxBitstream* bs, mfxSyncPoint* syncp);
 
 /* AudioDECODE */
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Query(mfxSession session,
                                                         mfxAudioParam* in,
                                                         mfxAudioParam* out);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioDECODE_DecodeHeader(mfxSession session,
-                            mfxBitstream* bs,
-                            mfxAudioParam* par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_DecodeHeader(
+    mfxSession session, mfxBitstream* bs, mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Init(mfxSession session,
                                                        mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Reset(mfxSession session,
                                                         mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Close(mfxSession session);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioDECODE_QueryIOSize(mfxSession session,
-                           mfxAudioParam* par,
-                           mfxAudioAllocRequest* request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_QueryIOSize(
+    mfxSession session, mfxAudioParam* par, mfxAudioAllocRequest* request);
 MFX_DEPRECATED mfxStatus MFX_CDECL
 MFXAudioDECODE_GetAudioParam(mfxSession session, mfxAudioParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioDECODE_DecodeFrameAsync(mfxSession session,
-                                mfxBitstream* bs,
-                                mfxAudioFrame* frame,
-                                mfxSyncPoint* syncp);
+MFXAudioDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream* bs,
+                                mfxAudioFrame* frame, mfxSyncPoint* syncp);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/win/include/mfxbrc.h
+++ b/src/win/include/mfxbrc.h
@@ -118,15 +118,13 @@ typedef struct {
 
   // Obtain from BRC controls required for frame encoding.
   // Will be invoked BEFORE encoding of each frame. In - pthis, par; Out - ctrl.
-  mfxStatus(MFX_CDECL* GetFrameCtrl)(mfxHDL pthis,
-                                     mfxBRCFrameParam* par,
+  mfxStatus(MFX_CDECL* GetFrameCtrl)(mfxHDL pthis, mfxBRCFrameParam* par,
                                      mfxBRCFrameCtrl* ctrl);
 
   // Update BRC state and return command to continue/recode frame/do
   // padding/skip frame. Will be invoked AFTER encoding of each frame. In -
   // pthis, par, ctrl; Out - status.
-  mfxStatus(MFX_CDECL* Update)(mfxHDL pthis,
-                               mfxBRCFrameParam* par,
+  mfxStatus(MFX_CDECL* Update)(mfxHDL pthis, mfxBRCFrameParam* par,
                                mfxBRCFrameCtrl* ctrl,
                                mfxBRCFrameStatus* status);
 
@@ -135,7 +133,7 @@ typedef struct {
 MFX_PACK_END()
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxenc.h
+++ b/src/win/include/mfxenc.h
@@ -56,10 +56,8 @@ MFX_PACK_END()
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Query(mfxSession session,
                                                      mfxVideoParam* in,
                                                      mfxVideoParam* out);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoENC_QueryIOSurf(mfxSession session,
-                        mfxVideoParam* par,
-                        mfxFrameAllocRequest* request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_QueryIOSurf(
+    mfxSession session, mfxVideoParam* par, mfxFrameAllocRequest* request);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Init(mfxSession session,
                                                     mfxVideoParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session,
@@ -67,16 +65,14 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session,
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Close(mfxSession session);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoENC_ProcessFrameAsync(mfxSession session,
-                              mfxENCInput* in,
-                              mfxENCOutput* out,
-                              mfxSyncPoint* syncp);
+MFXVideoENC_ProcessFrameAsync(mfxSession session, mfxENCInput* in,
+                              mfxENCOutput* out, mfxSyncPoint* syncp);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL
 MFXVideoENC_GetVideoParam(mfxSession session, mfxVideoParam* par);
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxfei.h
+++ b/src/win/include/mfxfei.h
@@ -68,7 +68,7 @@ MFX_DEPRECATED typedef struct {
 
   struct mfxExtFeiPreEncMVPredictorsMB {
     mfxI16Pair MV[2]; /* 0 for L0 and 1 for L1 */
-  } * MB;
+  }* MB;
 } mfxExtFeiPreEncMVPredictors;
 MFX_PACK_END()
 
@@ -95,7 +95,7 @@ MFX_DEPRECATED typedef struct {
 
   struct mfxExtFeiPreEncMVMB {
     mfxI16Pair MV[16][2];
-  } * MB;
+  }* MB;
 } mfxExtFeiPreEncMV;
 MFX_PACK_END()
 
@@ -125,7 +125,7 @@ MFX_DEPRECATED typedef struct {
     mfxU32 Variance8x8[4];
     mfxU32 PixelAverage16x16;
     mfxU32 PixelAverage8x8[4];
-  } * MB;
+  }* MB;
 } mfxExtFeiPreEncMBStat;
 MFX_PACK_END()
 
@@ -174,7 +174,7 @@ MFX_DEPRECATED typedef struct {
     mfxU32 reserved;
     mfxI16Pair MV[4][2]; /* first index is predictor number, second is 0 for L0
                             and 1 for L1 */
-  } * MB;
+  }* MB;
 } mfxExtFeiEncMVPredictors;
 MFX_PACK_END()
 
@@ -204,7 +204,7 @@ MFX_DEPRECATED typedef struct {
     mfxU32 reserved4 : 16;
     mfxU32 TargetSizeInWord : 8;
     mfxU32 MaxSizeInWord : 8;
-  } * MB;
+  }* MB;
 } mfxExtFeiEncMBCtrl;
 MFX_PACK_END()
 
@@ -233,7 +233,7 @@ MFX_DEPRECATED typedef struct {
   struct mfxExtFeiEncMVMB {
     mfxI16Pair MV[16][2]; /* first index is block (4x4 pixels) number, second is
                              0 for L0 and 1 for L1 */
-  } * MB;
+  }* MB;
 } mfxExtFeiEncMV;
 MFX_PACK_END()
 
@@ -251,7 +251,7 @@ MFX_DEPRECATED typedef struct {
     mfxU16 ColocatedMbDistortion;
     mfxU16 reserved;
     mfxU32 reserved1[2];
-  } * MB;
+  }* MB;
 } mfxExtFeiEncMBStat;
 MFX_PACK_END()
 
@@ -522,7 +522,7 @@ MFX_DEPRECATED typedef struct {
       mfxU16 reserved[2];
     } RefL0[32], RefL1[32]; /* index in mfxPAKInput::L0Surface array */
 
-  } * Slice;
+  }* Slice;
 } mfxExtFeiSliceHeader;
 MFX_PACK_END()
 
@@ -631,7 +631,7 @@ MFX_DEPRECATED typedef struct {
 MFX_PACK_END()
 
 #ifdef __cplusplus
-} /* extern "C" */
+}      /* extern "C" */
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxfeihevc.h
+++ b/src/win/include/mfxfeihevc.h
@@ -297,7 +297,7 @@ MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_EXTBUFF_HEVCFEI_ENC_DIST);
 #endif  // MFX_VERSION
 
 #ifdef __cplusplus
-} /* extern "C" */
+}      /* extern "C" */
 #endif /* __cplusplus */
 
 #endif  // __MFXFEIHEVC_H__

--- a/src/win/include/mfxjpeg.h
+++ b/src/win/include/mfxjpeg.h
@@ -90,7 +90,7 @@ typedef struct {
 MFX_PACK_END()
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif  // __MFX_JPEG_H__

--- a/src/win/include/mfxla.h
+++ b/src/win/include/mfxla.h
@@ -92,7 +92,7 @@ MFX_DEPRECATED typedef struct {
 MFX_PACK_END()
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxpak.h
+++ b/src/win/include/mfxpak.h
@@ -62,10 +62,8 @@ typedef struct _mfxSession* mfxSession;
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Query(mfxSession session,
                                                      mfxVideoParam* in,
                                                      mfxVideoParam* out);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoPAK_QueryIOSurf(mfxSession session,
-                        mfxVideoParam* par,
-                        mfxFrameAllocRequest request[2]);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_QueryIOSurf(
+    mfxSession session, mfxVideoParam* par, mfxFrameAllocRequest request[2]);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Init(mfxSession session,
                                                     mfxVideoParam* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session,
@@ -73,16 +71,14 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session,
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Close(mfxSession session);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoPAK_ProcessFrameAsync(mfxSession session,
-                              mfxPAKInput* in,
-                              mfxPAKOutput* out,
-                              mfxSyncPoint* syncp);
+MFXVideoPAK_ProcessFrameAsync(mfxSession session, mfxPAKInput* in,
+                              mfxPAKOutput* out, mfxSyncPoint* syncp);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL
 MFXVideoPAK_GetVideoParam(mfxSession session, mfxVideoParam* par);
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxplugin++.h
+++ b/src/win/include/mfxplugin++.h
@@ -33,10 +33,8 @@ class MFXBaseUSER {
 
   virtual mfxStatus Register(mfxU32 type, const mfxPlugin* par) = 0;
   virtual mfxStatus Unregister(mfxU32 type) = 0;
-  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in,
-                                      mfxU32 in_num,
-                                      const mfxHDL* out,
-                                      mfxU32 out_num,
+  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in, mfxU32 in_num,
+                                      const mfxHDL* out, mfxU32 out_num,
                                       mfxSyncPoint* syncp) = 0;
 
  protected:
@@ -54,10 +52,8 @@ class MFXVideoUSER : public MFXBaseUSER {
   virtual mfxStatus Unregister(mfxU32 type) {
     return MFXVideoUSER_Unregister(m_session, type);
   }
-  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in,
-                                      mfxU32 in_num,
-                                      const mfxHDL* out,
-                                      mfxU32 out_num,
+  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in, mfxU32 in_num,
+                                      const mfxHDL* out, mfxU32 out_num,
                                       mfxSyncPoint* syncp) {
     return MFXVideoUSER_ProcessFrameAsync(m_session, in, in_num, out, out_num,
                                           syncp);
@@ -75,10 +71,8 @@ class MFXAudioUSER : public MFXBaseUSER {
   virtual mfxStatus Unregister(mfxU32 type) {
     return MFXAudioUSER_Unregister(m_session, type);
   }
-  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in,
-                                      mfxU32 in_num,
-                                      const mfxHDL* out,
-                                      mfxU32 out_num,
+  virtual mfxStatus ProcessFrameAsync(const mfxHDL* in, mfxU32 in_num,
+                                      const mfxHDL* out, mfxU32 out_num,
                                       mfxSyncPoint* syncp) {
     return MFXAudioUSER_ProcessFrameAsync(m_session, in, in_num, out, out_num,
                                           syncp);
@@ -90,9 +84,7 @@ class MFXPluginParam {
   mfxPluginParam m_param;
 
  public:
-  MFXPluginParam(mfxU32 CodecId,
-                 mfxU32 Type,
-                 mfxPluginUID uid,
+  MFXPluginParam(mfxU32 CodecId, mfxU32 Type, mfxPluginUID uid,
                  mfxThreadPolicy ThreadPolicy = MFX_THREADPOLICY_SERIAL,
                  mfxU32 MaxThreadNum = 1)
       : m_param() {
@@ -133,8 +125,7 @@ struct MFXPlugin {
 // MFXPlugin
 struct MFXCodecPlugin : MFXPlugin {
   virtual mfxStatus Init(mfxVideoParam* par) = 0;
-  virtual mfxStatus QueryIOSurf(mfxVideoParam* par,
-                                mfxFrameAllocRequest* in,
+  virtual mfxStatus QueryIOSurf(mfxVideoParam* par, mfxFrameAllocRequest* in,
                                 mfxFrameAllocRequest* out) = 0;
   virtual mfxStatus Query(mfxVideoParam* in, mfxVideoParam* out) = 0;
   virtual mfxStatus Reset(mfxVideoParam* par) = 0;
@@ -155,14 +146,10 @@ struct MFXAudioCodecPlugin : MFXPlugin {
 // general purpose transform plugin interface, not a codec plugin
 struct MFXGenericPlugin : MFXPlugin {
   virtual mfxStatus Init(mfxVideoParam* par) = 0;
-  virtual mfxStatus QueryIOSurf(mfxVideoParam* par,
-                                mfxFrameAllocRequest* in,
+  virtual mfxStatus QueryIOSurf(mfxVideoParam* par, mfxFrameAllocRequest* in,
                                 mfxFrameAllocRequest* out) = 0;
-  virtual mfxStatus Submit(const mfxHDL* in,
-                           mfxU32 in_num,
-                           const mfxHDL* out,
-                           mfxU32 out_num,
-                           mfxThreadTask* task) = 0;
+  virtual mfxStatus Submit(const mfxHDL* in, mfxU32 in_num, const mfxHDL* out,
+                           mfxU32 out_num, mfxThreadTask* task) = 0;
 };
 
 // decoder plugins may only support this interface
@@ -179,8 +166,7 @@ struct MFXDecoderPlugin : MFXCodecPlugin {
 struct MFXAudioDecoderPlugin : MFXAudioCodecPlugin {
   virtual mfxStatus DecodeHeader(mfxBitstream* bs, mfxAudioParam* par) = 0;
   //    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) = 0;
-  virtual mfxStatus DecodeFrameSubmit(mfxBitstream* in,
-                                      mfxAudioFrame* out,
+  virtual mfxStatus DecodeFrameSubmit(mfxBitstream* in, mfxAudioFrame* out,
                                       mfxThreadTask* task) = 0;
 };
 
@@ -194,8 +180,7 @@ struct MFXEncoderPlugin : MFXCodecPlugin {
 
 // audio encoder plugins may only support this interface
 struct MFXAudioEncoderPlugin : MFXAudioCodecPlugin {
-  virtual mfxStatus EncodeFrameSubmit(mfxAudioFrame* aFrame,
-                                      mfxBitstream* out,
+  virtual mfxStatus EncodeFrameSubmit(mfxAudioFrame* aFrame, mfxBitstream* out,
                                       mfxThreadTask* task) = 0;
 };
 
@@ -212,8 +197,7 @@ struct MFXVPPPlugin : MFXCodecPlugin {
 };
 
 struct MFXEncPlugin : MFXCodecPlugin {
-  virtual mfxStatus EncFrameSubmit(mfxENCInput* in,
-                                   mfxENCOutput* out,
+  virtual mfxStatus EncFrameSubmit(mfxENCInput* in, mfxENCOutput* out,
                                    mfxThreadTask* task) = 0;
 };
 
@@ -267,16 +251,14 @@ class MFXCoreInterface {
     }
     return m_core.CopyBuffer(m_core.pthis, dst, size, src);
   }
-  mfxStatus MapOpaqueSurface(mfxU32 num,
-                             mfxU32 type,
+  mfxStatus MapOpaqueSurface(mfxU32 num, mfxU32 type,
                              mfxFrameSurface1** op_surf) {
     if (!IsCoreSet()) {
       return MFX_ERR_NULL_PTR;
     }
     return m_core.MapOpaqueSurface(m_core.pthis, num, type, op_surf);
   }
-  mfxStatus UnmapOpaqueSurface(mfxU32 num,
-                               mfxU32 type,
+  mfxStatus UnmapOpaqueSurface(mfxU32 num, mfxU32 type,
                                mfxFrameSurface1** op_surf) {
     if (!IsCoreSet()) {
       return MFX_ERR_NULL_PTR;
@@ -366,14 +348,11 @@ class MFXPluginAdapterBase {
   static mfxStatus _GetPluginParam(mfxHDL pthis, mfxPluginParam* par) {
     return reinterpret_cast<T*>(pthis)->GetPluginParam(par);
   }
-  static mfxStatus _Execute(mfxHDL pthis,
-                            mfxThreadTask task,
-                            mfxU32 thread_id,
+  static mfxStatus _Execute(mfxHDL pthis, mfxThreadTask task, mfxU32 thread_id,
                             mfxU32 call_count) {
     return reinterpret_cast<T*>(pthis)->Execute(task, thread_id, call_count);
   }
-  static mfxStatus _FreeResources(mfxHDL pthis,
-                                  mfxThreadTask task,
+  static mfxStatus _FreeResources(mfxHDL pthis, mfxThreadTask task,
                                   mfxStatus sts) {
     return reinterpret_cast<T*>(pthis)->FreeResources(task, sts);
   }
@@ -421,8 +400,7 @@ class MFXCodecPluginAdapterBase : public MFXPluginAdapterBase<T> {
   static mfxStatus _Query(mfxHDL pthis, mfxVideoParam* in, mfxVideoParam* out) {
     return reinterpret_cast<T*>(pthis)->Query(in, out);
   }
-  static mfxStatus _QueryIOSurf(mfxHDL pthis,
-                                mfxVideoParam* par,
+  static mfxStatus _QueryIOSurf(mfxHDL pthis, mfxVideoParam* par,
                                 mfxFrameAllocRequest* in,
                                 mfxFrameAllocRequest* out) {
     return reinterpret_cast<T*>(pthis)->QueryIOSurf(par, in, out);
@@ -483,8 +461,7 @@ class MFXAudioCodecPluginAdapterBase : public MFXPluginAdapterBase<T> {
   static mfxStatus _Query(mfxHDL pthis, mfxAudioParam* in, mfxAudioParam* out) {
     return reinterpret_cast<T*>(pthis)->Query(in, out);
   }
-  static mfxStatus _QueryIOSize(mfxHDL pthis,
-                                mfxAudioParam* par,
+  static mfxStatus _QueryIOSize(mfxHDL pthis, mfxAudioParam* par,
                                 mfxAudioAllocRequest* request) {
     return reinterpret_cast<T*>(pthis)->QueryIOSize(par, request);
   }
@@ -524,11 +501,8 @@ class MFXPluginAdapterInternal<MFXGenericPlugin>
   }
 
  private:
-  static mfxStatus _Submit(mfxHDL pthis,
-                           const mfxHDL* in,
-                           mfxU32 in_num,
-                           const mfxHDL* out,
-                           mfxU32 out_num,
+  static mfxStatus _Submit(mfxHDL pthis, const mfxHDL* in, mfxU32 in_num,
+                           const mfxHDL* out, mfxU32 out_num,
                            mfxThreadTask* task) {
     return reinterpret_cast<MFXGenericPlugin*>(pthis)->Submit(in, in_num, out,
                                                               out_num, task);
@@ -562,16 +536,14 @@ class MFXPluginAdapterInternal<MFXDecoderPlugin>
     m_codecPlg.GetPayload = _GetPayload;
     m_codecPlg.DecodeFrameSubmit = _DecodeFrameSubmit;
   }
-  static mfxStatus _DecodeHeader(mfxHDL pthis,
-                                 mfxBitstream* bs,
+  static mfxStatus _DecodeHeader(mfxHDL pthis, mfxBitstream* bs,
                                  mfxVideoParam* par) {
     return reinterpret_cast<MFXDecoderPlugin*>(pthis)->DecodeHeader(bs, par);
   }
   static mfxStatus _GetPayload(mfxHDL pthis, mfxU64* ts, mfxPayload* payload) {
     return reinterpret_cast<MFXDecoderPlugin*>(pthis)->GetPayload(ts, payload);
   }
-  static mfxStatus _DecodeFrameSubmit(mfxHDL pthis,
-                                      mfxBitstream* bs,
+  static mfxStatus _DecodeFrameSubmit(mfxHDL pthis, mfxBitstream* bs,
                                       mfxFrameSurface1* surface_work,
                                       mfxFrameSurface1** surface_out,
                                       mfxThreadTask* task) {
@@ -606,16 +578,13 @@ class MFXPluginAdapterInternal<MFXAudioDecoderPlugin>
     m_codecPlg.DecodeHeader = _DecodeHeader;
     m_codecPlg.DecodeFrameSubmit = _DecodeFrameSubmit;
   }
-  static mfxStatus _DecodeHeader(mfxHDL pthis,
-                                 mfxBitstream* bs,
+  static mfxStatus _DecodeHeader(mfxHDL pthis, mfxBitstream* bs,
                                  mfxAudioParam* par) {
     return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeHeader(bs,
                                                                          par);
   }
-  static mfxStatus _DecodeFrameSubmit(mfxHDL pthis,
-                                      mfxBitstream* in,
-                                      mfxAudioFrame* out,
-                                      mfxThreadTask* task) {
+  static mfxStatus _DecodeFrameSubmit(mfxHDL pthis, mfxBitstream* in,
+                                      mfxAudioFrame* out, mfxThreadTask* task) {
     return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeFrameSubmit(
         in, out, task);
   }
@@ -642,11 +611,9 @@ class MFXPluginAdapterInternal<MFXEncoderPlugin>
   }
 
  private:
-  static mfxStatus _EncodeFrameSubmit(mfxHDL pthis,
-                                      mfxEncodeCtrl* ctrl,
+  static mfxStatus _EncodeFrameSubmit(mfxHDL pthis, mfxEncodeCtrl* ctrl,
                                       mfxFrameSurface1* surface,
-                                      mfxBitstream* bs,
-                                      mfxThreadTask* task) {
+                                      mfxBitstream* bs, mfxThreadTask* task) {
     return reinterpret_cast<MFXEncoderPlugin*>(pthis)->EncodeFrameSubmit(
         ctrl, surface, bs, task);
   }
@@ -675,10 +642,8 @@ class MFXPluginAdapterInternal<MFXAudioEncoderPlugin>
 
  private:
   void SetupCallbacks() { m_codecPlg.EncodeFrameSubmit = _EncodeFrameSubmit; }
-  static mfxStatus _EncodeFrameSubmit(mfxHDL pthis,
-                                      mfxAudioFrame* aFrame,
-                                      mfxBitstream* out,
-                                      mfxThreadTask* task) {
+  static mfxStatus _EncodeFrameSubmit(mfxHDL pthis, mfxAudioFrame* aFrame,
+                                      mfxBitstream* out, mfxThreadTask* task) {
     return reinterpret_cast<MFXAudioEncoderPlugin*>(pthis)->EncodeFrameSubmit(
         aFrame, out, task);
   }
@@ -705,10 +670,8 @@ class MFXPluginAdapterInternal<MFXEncPlugin>
   }
 
  private:
-  static mfxStatus _ENCFrameSubmit(mfxHDL pthis,
-                                   mfxENCInput* in,
-                                   mfxENCOutput* out,
-                                   mfxThreadTask* task) {
+  static mfxStatus _ENCFrameSubmit(mfxHDL pthis, mfxENCInput* in,
+                                   mfxENCOutput* out, mfxThreadTask* task) {
     return reinterpret_cast<MFXEncPlugin*>(pthis)->EncFrameSubmit(in, out,
                                                                   task);
   }
@@ -739,16 +702,13 @@ class MFXPluginAdapterInternal<MFXVPPPlugin>
     m_codecPlg.VPPFrameSubmit = _VPPFrameSubmit;
     m_codecPlg.VPPFrameSubmitEx = _VPPFrameSubmitEx;
   }
-  static mfxStatus _VPPFrameSubmit(mfxHDL pthis,
-                                   mfxFrameSurface1* surface_in,
+  static mfxStatus _VPPFrameSubmit(mfxHDL pthis, mfxFrameSurface1* surface_in,
                                    mfxFrameSurface1* surface_out,
-                                   mfxExtVppAuxData* aux,
-                                   mfxThreadTask* task) {
+                                   mfxExtVppAuxData* aux, mfxThreadTask* task) {
     return reinterpret_cast<MFXVPPPlugin*>(pthis)->VPPFrameSubmit(
         surface_in, surface_out, aux, task);
   }
-  static mfxStatus _VPPFrameSubmitEx(mfxHDL pthis,
-                                     mfxFrameSurface1* surface_in,
+  static mfxStatus _VPPFrameSubmitEx(mfxHDL pthis, mfxFrameSurface1* surface_in,
                                      mfxFrameSurface1* surface_work,
                                      mfxFrameSurface1** surface_out,
                                      mfxThreadTask* task) {

--- a/src/win/include/mfxplugin.h
+++ b/src/win/include/mfxplugin.h
@@ -147,40 +147,30 @@ MFX_DEPRECATED typedef struct mfxCoreInterface {
   mfxBufferAllocator reserved3;
 
   mfxStatus(MFX_CDECL* GetCoreParam)(mfxHDL pthis, mfxCoreParam* par);
-  mfxStatus(MFX_CDECL* GetHandle)(mfxHDL pthis,
-                                  mfxHandleType type,
+  mfxStatus(MFX_CDECL* GetHandle)(mfxHDL pthis, mfxHandleType type,
                                   mfxHDL* handle);
   mfxStatus(MFX_CDECL* IncreaseReference)(mfxHDL pthis, mfxFrameData* fd);
   mfxStatus(MFX_CDECL* DecreaseReference)(mfxHDL pthis, mfxFrameData* fd);
-  mfxStatus(MFX_CDECL* CopyFrame)(mfxHDL pthis,
-                                  mfxFrameSurface1* dst,
+  mfxStatus(MFX_CDECL* CopyFrame)(mfxHDL pthis, mfxFrameSurface1* dst,
                                   mfxFrameSurface1* src);
-  mfxStatus(MFX_CDECL* CopyBuffer)(mfxHDL pthis,
-                                   mfxU8* dst,
-                                   mfxU32 size,
+  mfxStatus(MFX_CDECL* CopyBuffer)(mfxHDL pthis, mfxU8* dst, mfxU32 size,
                                    mfxFrameSurface1* src);
 
-  mfxStatus(MFX_CDECL* MapOpaqueSurface)(mfxHDL pthis,
-                                         mfxU32 num,
-                                         mfxU32 type,
+  mfxStatus(MFX_CDECL* MapOpaqueSurface)(mfxHDL pthis, mfxU32 num, mfxU32 type,
                                          mfxFrameSurface1** op_surf);
-  mfxStatus(MFX_CDECL* UnmapOpaqueSurface)(mfxHDL pthis,
-                                           mfxU32 num,
+  mfxStatus(MFX_CDECL* UnmapOpaqueSurface)(mfxHDL pthis, mfxU32 num,
                                            mfxU32 type,
                                            mfxFrameSurface1** op_surf);
 
-  mfxStatus(MFX_CDECL* GetRealSurface)(mfxHDL pthis,
-                                       mfxFrameSurface1* op_surf,
+  mfxStatus(MFX_CDECL* GetRealSurface)(mfxHDL pthis, mfxFrameSurface1* op_surf,
                                        mfxFrameSurface1** surf);
-  mfxStatus(MFX_CDECL* GetOpaqueSurface)(mfxHDL pthis,
-                                         mfxFrameSurface1* surf,
+  mfxStatus(MFX_CDECL* GetOpaqueSurface)(mfxHDL pthis, mfxFrameSurface1* surf,
                                          mfxFrameSurface1** op_surf);
 
   mfxStatus(MFX_CDECL* CreateAccelerationDevice)(mfxHDL pthis,
                                                  mfxHandleType type,
                                                  mfxHDL* handle);
-  mfxStatus(MFX_CDECL* GetFrameHandle)(mfxHDL pthis,
-                                       mfxFrameData* fd,
+  mfxStatus(MFX_CDECL* GetFrameHandle)(mfxHDL pthis, mfxFrameData* fd,
                                        mfxHDL* handle);
   mfxStatus(MFX_CDECL* QueryPlatform)(mfxHDL pthis, mfxPlatform* platform);
 
@@ -193,11 +183,9 @@ MFX_PACK_BEGIN_STRUCT_W_PTR()
 MFX_DEPRECATED typedef struct _mfxENCInput mfxENCInput;
 MFX_DEPRECATED typedef struct _mfxENCOutput mfxENCOutput;
 MFX_DEPRECATED typedef struct mfxVideoCodecPlugin {
-  mfxStatus(MFX_CDECL* Query)(mfxHDL pthis,
-                              mfxVideoParam* in,
+  mfxStatus(MFX_CDECL* Query)(mfxHDL pthis, mfxVideoParam* in,
                               mfxVideoParam* out);
-  mfxStatus(MFX_CDECL* QueryIOSurf)(mfxHDL pthis,
-                                    mfxVideoParam* par,
+  mfxStatus(MFX_CDECL* QueryIOSurf)(mfxHDL pthis, mfxVideoParam* par,
                                     mfxFrameAllocRequest* in,
                                     mfxFrameAllocRequest* out);
   mfxStatus(MFX_CDECL* Init)(mfxHDL pthis, mfxVideoParam* par);
@@ -205,39 +193,31 @@ MFX_DEPRECATED typedef struct mfxVideoCodecPlugin {
   mfxStatus(MFX_CDECL* Close)(mfxHDL pthis);
   mfxStatus(MFX_CDECL* GetVideoParam)(mfxHDL pthis, mfxVideoParam* par);
 
-  mfxStatus(MFX_CDECL* EncodeFrameSubmit)(mfxHDL pthis,
-                                          mfxEncodeCtrl* ctrl,
+  mfxStatus(MFX_CDECL* EncodeFrameSubmit)(mfxHDL pthis, mfxEncodeCtrl* ctrl,
                                           mfxFrameSurface1* surface,
                                           mfxBitstream* bs,
                                           mfxThreadTask* task);
 
-  mfxStatus(MFX_CDECL* DecodeHeader)(mfxHDL pthis,
-                                     mfxBitstream* bs,
+  mfxStatus(MFX_CDECL* DecodeHeader)(mfxHDL pthis, mfxBitstream* bs,
                                      mfxVideoParam* par);
-  mfxStatus(MFX_CDECL* GetPayload)(mfxHDL pthis,
-                                   mfxU64* ts,
+  mfxStatus(MFX_CDECL* GetPayload)(mfxHDL pthis, mfxU64* ts,
                                    mfxPayload* payload);
-  mfxStatus(MFX_CDECL* DecodeFrameSubmit)(mfxHDL pthis,
-                                          mfxBitstream* bs,
+  mfxStatus(MFX_CDECL* DecodeFrameSubmit)(mfxHDL pthis, mfxBitstream* bs,
                                           mfxFrameSurface1* surface_work,
                                           mfxFrameSurface1** surface_out,
                                           mfxThreadTask* task);
 
-  mfxStatus(MFX_CDECL* VPPFrameSubmit)(mfxHDL pthis,
-                                       mfxFrameSurface1* in,
+  mfxStatus(MFX_CDECL* VPPFrameSubmit)(mfxHDL pthis, mfxFrameSurface1* in,
                                        mfxFrameSurface1* out,
                                        mfxExtVppAuxData* aux,
                                        mfxThreadTask* task);
-  mfxStatus(MFX_CDECL* VPPFrameSubmitEx)(mfxHDL pthis,
-                                         mfxFrameSurface1* in,
+  mfxStatus(MFX_CDECL* VPPFrameSubmitEx)(mfxHDL pthis, mfxFrameSurface1* in,
                                          mfxFrameSurface1* surface_work,
                                          mfxFrameSurface1** surface_out,
                                          mfxThreadTask* task);
 
-  mfxStatus(MFX_CDECL* ENCFrameSubmit)(mfxHDL pthis,
-                                       mfxENCInput* in,
-                                       mfxENCOutput* out,
-                                       mfxThreadTask* task);
+  mfxStatus(MFX_CDECL* ENCFrameSubmit)(mfxHDL pthis, mfxENCInput* in,
+                                       mfxENCOutput* out, mfxThreadTask* task);
 
   mfxHDL reserved1[3];
   mfxU32 reserved2[8];
@@ -246,29 +226,24 @@ MFX_PACK_END()
 
 MFX_PACK_BEGIN_STRUCT_W_PTR()
 MFX_DEPRECATED typedef struct mfxAudioCodecPlugin {
-  mfxStatus(MFX_CDECL* Query)(mfxHDL pthis,
-                              mfxAudioParam* in,
+  mfxStatus(MFX_CDECL* Query)(mfxHDL pthis, mfxAudioParam* in,
                               mfxAudioParam* out);
-  mfxStatus(MFX_CDECL* QueryIOSize)(mfxHDL pthis,
-                                    mfxAudioParam* par,
+  mfxStatus(MFX_CDECL* QueryIOSize)(mfxHDL pthis, mfxAudioParam* par,
                                     mfxAudioAllocRequest* request);
   mfxStatus(MFX_CDECL* Init)(mfxHDL pthis, mfxAudioParam* par);
   mfxStatus(MFX_CDECL* Reset)(mfxHDL pthis, mfxAudioParam* par);
   mfxStatus(MFX_CDECL* Close)(mfxHDL pthis);
   mfxStatus(MFX_CDECL* GetAudioParam)(mfxHDL pthis, mfxAudioParam* par);
 
-  mfxStatus(MFX_CDECL* EncodeFrameSubmit)(mfxHDL pthis,
-                                          mfxAudioFrame* aFrame,
+  mfxStatus(MFX_CDECL* EncodeFrameSubmit)(mfxHDL pthis, mfxAudioFrame* aFrame,
                                           mfxBitstream* out,
                                           mfxThreadTask* task);
 
-  mfxStatus(MFX_CDECL* DecodeHeader)(mfxHDL pthis,
-                                     mfxBitstream* bs,
+  mfxStatus(MFX_CDECL* DecodeHeader)(mfxHDL pthis, mfxBitstream* bs,
                                      mfxAudioParam* par);
   //    mfxStatus (MFX_CDECL *GetPayload)(mfxHDL pthis, mfxU64 *ts, mfxPayload
   //    *payload);
-  mfxStatus(MFX_CDECL* DecodeFrameSubmit)(mfxHDL pthis,
-                                          mfxBitstream* in,
+  mfxStatus(MFX_CDECL* DecodeFrameSubmit)(mfxHDL pthis, mfxBitstream* in,
                                           mfxAudioFrame* out,
                                           mfxThreadTask* task);
 
@@ -286,18 +261,12 @@ MFX_DEPRECATED typedef struct mfxPlugin {
 
   mfxStatus(MFX_CDECL* GetPluginParam)(mfxHDL pthis, mfxPluginParam* par);
 
-  mfxStatus(MFX_CDECL* Submit)(mfxHDL pthis,
-                               const mfxHDL* in,
-                               mfxU32 in_num,
-                               const mfxHDL* out,
-                               mfxU32 out_num,
+  mfxStatus(MFX_CDECL* Submit)(mfxHDL pthis, const mfxHDL* in, mfxU32 in_num,
+                               const mfxHDL* out, mfxU32 out_num,
                                mfxThreadTask* task);
-  mfxStatus(MFX_CDECL* Execute)(mfxHDL pthis,
-                                mfxThreadTask task,
-                                mfxU32 uid_p,
+  mfxStatus(MFX_CDECL* Execute)(mfxHDL pthis, mfxThreadTask task, mfxU32 uid_p,
                                 mfxU32 uid_a);
-  mfxStatus(MFX_CDECL* FreeResources)(mfxHDL pthis,
-                                      mfxThreadTask task,
+  mfxStatus(MFX_CDECL* FreeResources)(mfxHDL pthis, mfxThreadTask task,
                                       mfxStatus sts);
 
   union {
@@ -317,23 +286,16 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Unregister(mfxSession session,
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_GetPlugin(mfxSession session,
                                                           mfxU32 type,
                                                           mfxPlugin* par);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoUSER_ProcessFrameAsync(mfxSession session,
-                               const mfxHDL* in,
-                               mfxU32 in_num,
-                               const mfxHDL* out,
-                               mfxU32 out_num,
-                               mfxSyncPoint* syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_ProcessFrameAsync(
+    mfxSession session, const mfxHDL* in, mfxU32 in_num, const mfxHDL* out,
+    mfxU32 out_num, mfxSyncPoint* syncp);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Load(mfxSession session,
                                                      const mfxPluginUID* uid,
                                                      mfxU32 version);
 MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoUSER_LoadByPath(mfxSession session,
-                        const mfxPluginUID* uid,
-                        mfxU32 version,
-                        const mfxChar* path,
-                        mfxU32 len);
+MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID* uid,
+                        mfxU32 version, const mfxChar* path, mfxU32 len);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_UnLoad(mfxSession session,
                                                        const mfxPluginUID* uid);
 
@@ -342,13 +304,9 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Register(mfxSession session,
                                                          const mfxPlugin* par);
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Unregister(mfxSession session,
                                                            mfxU32 type);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXAudioUSER_ProcessFrameAsync(mfxSession session,
-                               const mfxHDL* in,
-                               mfxU32 in_num,
-                               const mfxHDL* out,
-                               mfxU32 out_num,
-                               mfxSyncPoint* syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_ProcessFrameAsync(
+    mfxSession session, const mfxHDL* in, mfxU32 in_num, const mfxHDL* out,
+    mfxU32 out_num, mfxSyncPoint* syncp);
 
 MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Load(mfxSession session,
                                                      const mfxPluginUID* uid,
@@ -357,7 +315,7 @@ MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_UnLoad(mfxSession session,
                                                        const mfxPluginUID* uid);
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif /* __MFXPLUGIN_H__ */

--- a/src/win/include/mfxsc.h
+++ b/src/win/include/mfxsc.h
@@ -41,7 +41,7 @@ typedef struct {
 MFX_PACK_END()
 
 #ifdef __cplusplus
-}  // extern "C"
+}      // extern "C"
 #endif /* __cplusplus */
 
 #endif

--- a/src/win/include/mfxstructures.h
+++ b/src/win/include/mfxstructures.h
@@ -97,19 +97,14 @@ enum {
   MFX_FOURCC_YUY2 = MFX_MAKEFOURCC('Y', 'U', 'Y', '2'),
 #if (MFX_VERSION >= 1028)
   MFX_FOURCC_RGB565 = MFX_MAKEFOURCC(
-      'R',
-      'G',
-      'B',
+      'R', 'G', 'B',
       '2'), /* 2 bytes per pixel, uint16 in little-endian format, where 0-4 bits
                are blue, bits 5-10 are green and bits 11-15 are red */
   MFX_FOURCC_RGBP = MFX_MAKEFOURCC('R', 'G', 'B', 'P'),
 #endif
   MFX_FOURCC_RGB3 = MFX_MAKEFOURCC('R', 'G', 'B', '3'), /* deprecated */
-  MFX_FOURCC_RGB4 =
-      MFX_MAKEFOURCC('R',
-                     'G',
-                     'B',
-                     '4'), /* ARGB in that order, A channel is 8 MSBs */
+  MFX_FOURCC_RGB4 = MFX_MAKEFOURCC(
+      'R', 'G', 'B', '4'), /* ARGB in that order, A channel is 8 MSBs */
   MFX_FOURCC_P8 = 41,      /*  D3DFMT_P8   */
   MFX_FOURCC_P8_TEXTURE = MFX_MAKEFOURCC('P', '8', 'M', 'B'),
   MFX_FOURCC_P010 = MFX_MAKEFOURCC('P', '0', '1', '0'),
@@ -117,36 +112,22 @@ enum {
   MFX_FOURCC_P016 = MFX_MAKEFOURCC('P', '0', '1', '6'),
 #endif
   MFX_FOURCC_P210 = MFX_MAKEFOURCC('P', '2', '1', '0'),
-  MFX_FOURCC_BGR4 =
-      MFX_MAKEFOURCC('B',
-                     'G',
-                     'R',
-                     '4'), /* ABGR in that order, A channel is 8 MSBs */
-  MFX_FOURCC_A2RGB10 =
-      MFX_MAKEFOURCC('R',
-                     'G',
-                     '1',
-                     '0'), /* ARGB in that order, A channel is two MSBs */
+  MFX_FOURCC_BGR4 = MFX_MAKEFOURCC(
+      'B', 'G', 'R', '4'), /* ABGR in that order, A channel is 8 MSBs */
+  MFX_FOURCC_A2RGB10 = MFX_MAKEFOURCC(
+      'R', 'G', '1', '0'), /* ARGB in that order, A channel is two MSBs */
   MFX_FOURCC_ARGB16 = MFX_MAKEFOURCC(
-      'R',
-      'G',
-      '1',
+      'R', 'G', '1',
       '6'), /* ARGB in that order, 64 bits, A channel is 16 MSBs */
   MFX_FOURCC_ABGR16 = MFX_MAKEFOURCC(
-      'B',
-      'G',
-      '1',
+      'B', 'G', '1',
       '6'), /* ABGR in that order, 64 bits, A channel is 16 MSBs */
   MFX_FOURCC_R16 = MFX_MAKEFOURCC('R', '1', '6', 'U'),
   MFX_FOURCC_AYUV = MFX_MAKEFOURCC(
-      'A',
-      'Y',
-      'U',
+      'A', 'Y', 'U',
       'V'), /* YUV 4:4:4, AYUV in that order, A channel is 8 MSBs */
   MFX_FOURCC_AYUV_RGB4 = MFX_MAKEFOURCC(
-      'A',
-      'V',
-      'U',
+      'A', 'V', 'U',
       'Y'), /* ARGB in that order, A channel is 8 MSBs stored in AYUV surface*/
   MFX_FOURCC_UYVY = MFX_MAKEFOURCC('U', 'Y', 'V', 'Y'),
 #if (MFX_VERSION >= 1027)
@@ -157,20 +138,13 @@ enum {
   MFX_FOURCC_Y216 = MFX_MAKEFOURCC('Y', '2', '1', '6'),
   MFX_FOURCC_Y416 = MFX_MAKEFOURCC('Y', '4', '1', '6'),
 #endif
-  MFX_FOURCC_NV21 =
-      MFX_MAKEFOURCC('N',
-                     'V',
-                     '2',
-                     '1'), /* Same as NV12 but with weaved V and U values. */
+  MFX_FOURCC_NV21 = MFX_MAKEFOURCC(
+      'N', 'V', '2', '1'), /* Same as NV12 but with weaved V and U values. */
   MFX_FOURCC_IYUV = MFX_MAKEFOURCC(
-      'I',
-      'Y',
-      'U',
+      'I', 'Y', 'U',
       'V'), /* Same as  YV12 except that the U and V plane order is reversed. */
   MFX_FOURCC_I010 = MFX_MAKEFOURCC(
-      'I',
-      '0',
-      '1',
+      'I', '0', '1',
       '0'), /* 10-bit YUV 4:2:0, each component has its own plane. */
 };
 
@@ -1800,7 +1774,7 @@ typedef struct {
     mfxU32 Bottom; /* Bottom Area's coordinate. */
 
     mfxU16 reserved2[8];
-  } * Areas; /* Array of areas. */
+  }* Areas; /* Array of areas. */
 } mfxExtEncoderIPCMArea;
 MFX_PACK_END()
 

--- a/src/win/include/mfxvideo++.h
+++ b/src/win/include/mfxvideo++.h
@@ -125,8 +125,7 @@ class MFXVideoENCODE {
 
   virtual mfxStatus EncodeFrameAsync(mfxEncodeCtrl* ctrl,
                                      mfxFrameSurface1* surface,
-                                     mfxBitstream* bs,
-                                     mfxSyncPoint* syncp) {
+                                     mfxBitstream* bs, mfxSyncPoint* syncp) {
     return MFXVideoENCODE_EncodeFrameAsync(m_session, ctrl, surface, bs, syncp);
   }
 
@@ -248,8 +247,7 @@ class MFXVideoENC {
   virtual mfxStatus GetVideoParam(mfxVideoParam* par) {
     return MFXVideoENC_GetVideoParam(m_session, par);
   }
-  virtual mfxStatus ProcessFrameAsync(mfxENCInput* in,
-                                      mfxENCOutput* out,
+  virtual mfxStatus ProcessFrameAsync(mfxENCInput* in, mfxENCOutput* out,
                                       mfxSyncPoint* syncp) {
     return MFXVideoENC_ProcessFrameAsync(m_session, in, out, syncp);
   }
@@ -284,8 +282,7 @@ class MFXVideoPAK {
   // virtual mfxStatus GetEncodeStat(mfxEncodeStat *stat) { return
   // MFXVideoENCODE_GetEncodeStat(m_session, stat); }
 
-  virtual mfxStatus ProcessFrameAsync(mfxPAKInput* in,
-                                      mfxPAKOutput* out,
+  virtual mfxStatus ProcessFrameAsync(mfxPAKInput* in, mfxPAKOutput* out,
                                       mfxSyncPoint* syncp) {
     return MFXVideoPAK_ProcessFrameAsync(m_session, in, out, syncp);
   }

--- a/src/win/include/mfxvideo.h
+++ b/src/win/include/mfxvideo.h
@@ -31,9 +31,7 @@ MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
   mfxU32 reserved[4];
   mfxHDL pthis;
-  mfxStatus(MFX_CDECL* Alloc)(mfxHDL pthis,
-                              mfxU32 nbytes,
-                              mfxU16 type,
+  mfxStatus(MFX_CDECL* Alloc)(mfxHDL pthis, mfxU32 nbytes, mfxU16 type,
                               mfxMemId* mid);
   mfxStatus(MFX_CDECL* Lock)(mfxHDL pthis, mfxMemId mid, mfxU8** ptr);
   mfxStatus(MFX_CDECL* Unlock)(mfxHDL pthis, mfxMemId mid);
@@ -46,8 +44,7 @@ typedef struct {
   mfxU32 reserved[4];
   mfxHDL pthis;
 
-  mfxStatus(MFX_CDECL* Alloc)(mfxHDL pthis,
-                              mfxFrameAllocRequest* request,
+  mfxStatus(MFX_CDECL* Alloc)(mfxHDL pthis, mfxFrameAllocRequest* request,
                               mfxFrameAllocResponse* response);
   mfxStatus(MFX_CDECL* Lock)(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
   mfxStatus(MFX_CDECL* Unlock)(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
@@ -57,27 +54,21 @@ typedef struct {
 MFX_PACK_END()
 
 /* VideoCORE */
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoCORE_SetBufferAllocator(mfxSession session,
-                                mfxBufferAllocator* allocator);
-mfxStatus MFX_CDECL
-MFXVideoCORE_SetFrameAllocator(mfxSession session,
-                               mfxFrameAllocator* allocator);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoCORE_SetBufferAllocator(
+    mfxSession session, mfxBufferAllocator* allocator);
+mfxStatus MFX_CDECL MFXVideoCORE_SetFrameAllocator(
+    mfxSession session, mfxFrameAllocator* allocator);
 mfxStatus MFX_CDECL MFXVideoCORE_SetHandle(mfxSession session,
-                                           mfxHandleType type,
-                                           mfxHDL hdl);
+                                           mfxHandleType type, mfxHDL hdl);
 mfxStatus MFX_CDECL MFXVideoCORE_GetHandle(mfxSession session,
-                                           mfxHandleType type,
-                                           mfxHDL* hdl);
+                                           mfxHandleType type, mfxHDL* hdl);
 mfxStatus MFX_CDECL MFXVideoCORE_QueryPlatform(mfxSession session,
                                                mfxPlatform* platform);
 mfxStatus MFX_CDECL MFXVideoCORE_SyncOperation(mfxSession session,
-                                               mfxSyncPoint syncp,
-                                               mfxU32 wait);
+                                               mfxSyncPoint syncp, mfxU32 wait);
 
 /* VideoENCODE */
-mfxStatus MFX_CDECL MFXVideoENCODE_Query(mfxSession session,
-                                         mfxVideoParam* in,
+mfxStatus MFX_CDECL MFXVideoENCODE_Query(mfxSession session, mfxVideoParam* in,
                                          mfxVideoParam* out);
 mfxStatus MFX_CDECL MFXVideoENCODE_QueryIOSurf(mfxSession session,
                                                mfxVideoParam* par,
@@ -98,8 +89,7 @@ mfxStatus MFX_CDECL MFXVideoENCODE_EncodeFrameAsync(mfxSession session,
                                                     mfxSyncPoint* syncp);
 
 /* VideoDECODE */
-mfxStatus MFX_CDECL MFXVideoDECODE_Query(mfxSession session,
-                                         mfxVideoParam* in,
+mfxStatus MFX_CDECL MFXVideoDECODE_Query(mfxSession session, mfxVideoParam* in,
                                          mfxVideoParam* out);
 mfxStatus MFX_CDECL MFXVideoDECODE_DecodeHeader(mfxSession session,
                                                 mfxBitstream* bs,
@@ -118,19 +108,14 @@ mfxStatus MFX_CDECL MFXVideoDECODE_GetDecodeStat(mfxSession session,
                                                  mfxDecodeStat* stat);
 mfxStatus MFX_CDECL MFXVideoDECODE_SetSkipMode(mfxSession session,
                                                mfxSkipMode mode);
-mfxStatus MFX_CDECL MFXVideoDECODE_GetPayload(mfxSession session,
-                                              mfxU64* ts,
+mfxStatus MFX_CDECL MFXVideoDECODE_GetPayload(mfxSession session, mfxU64* ts,
                                               mfxPayload* payload);
-mfxStatus MFX_CDECL
-MFXVideoDECODE_DecodeFrameAsync(mfxSession session,
-                                mfxBitstream* bs,
-                                mfxFrameSurface1* surface_work,
-                                mfxFrameSurface1** surface_out,
-                                mfxSyncPoint* syncp);
+mfxStatus MFX_CDECL MFXVideoDECODE_DecodeFrameAsync(
+    mfxSession session, mfxBitstream* bs, mfxFrameSurface1* surface_work,
+    mfxFrameSurface1** surface_out, mfxSyncPoint* syncp);
 
 /* VideoVPP */
-mfxStatus MFX_CDECL MFXVideoVPP_Query(mfxSession session,
-                                      mfxVideoParam* in,
+mfxStatus MFX_CDECL MFXVideoVPP_Query(mfxSession session, mfxVideoParam* in,
                                       mfxVideoParam* out);
 mfxStatus MFX_CDECL MFXVideoVPP_QueryIOSurf(mfxSession session,
                                             mfxVideoParam* par,
@@ -148,12 +133,9 @@ mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsync(mfxSession session,
                                                  mfxFrameSurface1* out,
                                                  mfxExtVppAuxData* aux,
                                                  mfxSyncPoint* syncp);
-MFX_DEPRECATED mfxStatus MFX_CDECL
-MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session,
-                               mfxFrameSurface1* in,
-                               mfxFrameSurface1* surface_work,
-                               mfxFrameSurface1** surface_out,
-                               mfxSyncPoint* syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsyncEx(
+    mfxSession session, mfxFrameSurface1* in, mfxFrameSurface1* surface_work,
+    mfxFrameSurface1** surface_out, mfxSyncPoint* syncp);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/win/mediacapabilities.cc
+++ b/src/win/mediacapabilities.cc
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/mediacapabilities.h"
+
 #include <string>
 #include <vector>
+
 #include "mfxcommon.h"
 #include "mfxstructures.h"
 #include "rtc_base/logging.h"
@@ -54,8 +56,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoEncoder(
     unsigned short platform_code = mfx_platform_.CodeName;
     if (platform_code >= MFX_PLATFORM_HASWELL) {
       support_h264 = true;
-      if (platform_code > MFX_PLATFORM_BROADWELL)
-        h264_lp = true;
+      if (platform_code > MFX_PLATFORM_BROADWELL) h264_lp = true;
       if (platform_code >= MFX_PLATFORM_KABYLAKE) {
         // Spec says KBL/CFL/ICL/TGL. Apply to all after KBL.
         h264_argb = true;
@@ -81,15 +82,13 @@ MediaCapabilities::SupportedCapabilitiesForVideoEncoder(
           video_param.mfx.CodecId = MFX_CODEC_VP9;
           video_param.mfx.CodecProfile = MFX_PROFILE_VP9_0;
           sts = mfx_encoder_->Query(nullptr, &video_param);
-          if (sts != MFX_ERR_NONE)
-            support_vp9_8 &= false;
+          if (sts != MFX_ERR_NONE) support_vp9_8 &= false;
 
           memset(&video_param, 0, sizeof(video_param));
           video_param.mfx.CodecId = MFX_CODEC_VP9;
           video_param.mfx.CodecProfile = MFX_PROFILE_VP9_2;
           sts = mfx_encoder_->Query(nullptr, &video_param);
-          if (sts != MFX_ERR_NONE)
-            support_vp9_10 &= false;
+          if (sts != MFX_ERR_NONE) support_vp9_10 &= false;
 
           // VP9 will always be low power. And for MSDK, temporal scalability
           // and tiles don't work togehter. Also be noted we only support
@@ -134,8 +133,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoEncoder(
           video_param.mfx.CodecId = MFX_CODEC_AVC;
           // Don't check profiles. We know we can support from CB up to High.
           sts = mfx_encoder_->Query(nullptr, &video_param);
-          if (sts != MFX_ERR_NONE)
-            support_h264 &= false;
+          if (sts != MFX_ERR_NONE) support_h264 &= false;
 
           if (support_h264) {
             VideoEncoderCapability avc_cap;
@@ -170,8 +168,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoDecoder(
     unsigned short platform_code = mfx_platform_.CodeName;
     for (auto& codec : codec_types) {
       if (codec == owt::base::VideoCodec::kVp9) {
-        if (platform_code < MFX_PLATFORM_KABYLAKE)
-          continue;
+        if (platform_code < MFX_PLATFORM_KABYLAKE) continue;
 
         memset(&video_param, 0, sizeof(video_param));
         video_param.mfx.CodecId = MFX_CODEC_VP9;
@@ -277,26 +274,21 @@ MediaCapabilities::~MediaCapabilities() {
 bool MediaCapabilities::Init() {
   bool res = false;
   msdk_factory_ = owt::base::MSDKFactory::Get();
-  if (!msdk_factory_)
-    goto failed;
+  if (!msdk_factory_) goto failed;
 
   mfx_session_ = msdk_factory_->CreateSession();
-  if (!mfx_session_)
-    goto failed;
+  if (!mfx_session_) goto failed;
 
   // Create the underlying MFXVideoDECODE and MFXVideoENCODE
   // instances.
   mfx_encoder_.reset(new MFXVideoENCODE(*mfx_session_));
-  if (!mfx_encoder_)
-    goto failed;
+  if (!mfx_encoder_) goto failed;
 
   mfx_decoder_.reset(new MFXVideoDECODE(*mfx_session_));
-  if (!mfx_decoder_)
-    goto failed;
+  if (!mfx_decoder_) goto failed;
 
   res = msdk_factory_->QueryPlatform(mfx_session_, &mfx_platform_);
-  if (res)
-    inited_ = true;
+  if (res) inited_ = true;
 failed:
   return res;
 }

--- a/src/win/mediacapabilities.h
+++ b/src/win/mediacapabilities.h
@@ -7,6 +7,7 @@
 
 #include <mutex>
 #include <vector>
+
 #include "base_allocator.h"
 #include "mfxvideo++.h"
 #include "src/win/commontypes.h"

--- a/src/win/mediautils.cc
+++ b/src/win/mediautils.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <map>
 #include <string>
+
 #include "absl/types/optional.h"
 #include "common_video/h264/h264_common.h"
 // #include "common_video/h264/prefix_parser.h"
@@ -94,11 +95,8 @@ absl::optional<unsigned int> MediaUtils::GetH264TemporalLayers() {
   layers = std::max(layers, 1u);
   return layers;
 }
-bool ParseSlice(const uint8_t* slice,
-                size_t length,
-                int& temporal_id,
-                int& priority_id,
-                bool& is_idr) {
+bool ParseSlice(const uint8_t* slice, size_t length, int& temporal_id,
+                int& priority_id, bool& is_idr) {
   // using namespace webrtc;
   // webrtc::H264::NaluType nalu_type = webrtc::H264::ParseNaluType(slice[0]);
   // absl::optional<PrefixParser::PrefixState> prefix_state;
@@ -122,10 +120,8 @@ bool ParseSlice(const uint8_t* slice,
 
   return false;
 }
-bool MediaUtils::GetH264TemporalInfo(uint8_t* buffer,
-                                     size_t buffer_length,
-                                     int& temporal_id,
-                                     int& priority_id,
+bool MediaUtils::GetH264TemporalInfo(uint8_t* buffer, size_t buffer_length,
+                                     int& temporal_id, int& priority_id,
                                      bool& is_idr) {
   bool prefix_nal_found = false;
   std::vector<webrtc::H264::NaluIndex> nalu_indices =
@@ -134,16 +130,14 @@ bool MediaUtils::GetH264TemporalInfo(uint8_t* buffer,
     prefix_nal_found =
         ParseSlice(&buffer[index.payload_start_offset], index.payload_size,
                    temporal_id, priority_id, is_idr);
-    if (prefix_nal_found)
-      return true;
+    if (prefix_nal_found) return true;
   }
   return prefix_nal_found;
 }
 
 absl::optional<AV1Profile> StringToAV1Profile(const std::string& str) {
   const absl::optional<int> i = rtc::StringToNumber<int>(str);
-  if (!i.has_value())
-    return absl::nullopt;
+  if (!i.has_value()) return absl::nullopt;
 
   switch (i.value()) {
     case 0:
@@ -161,8 +155,7 @@ absl::optional<AV1Profile> StringToAV1Profile(const std::string& str) {
 absl::optional<H265ProfileId> StringToH265Profile(const std::string& str) {
 #ifdef OWT_USE_MSDK
   const absl::optional<int> i = rtc::StringToNumber<int>(str);
-  if (!i.has_value())
-    return absl::nullopt;
+  if (!i.has_value()) return absl::nullopt;
   // See ISO/IEC-23008-2 section A.3.5. we use the general_profile_idc
   // as the profile-id per RFC 7798.
   switch (i.value()) {
@@ -189,8 +182,7 @@ absl::optional<AV1Profile> MediaUtils::ParseSdpForAV1Profile(
     const webrtc::SdpVideoFormat::Parameters& params) {
   const char kAV1FmtpProfileId[] = "profile";
   const auto profile_it = params.find(kAV1FmtpProfileId);
-  if (profile_it == params.end())
-    return AV1Profile::kMain;
+  if (profile_it == params.end()) return AV1Profile::kMain;
   const std::string& profile_str = profile_it->second;
   return StringToAV1Profile(profile_str);
 }
@@ -199,8 +191,7 @@ absl::optional<H265ProfileId> MediaUtils::ParseSdpForH265Profile(
     const webrtc::SdpVideoFormat::Parameters& params) {
   const char kHEVCFmtpProfileId[] = "profile-id";
   const auto profile_it = params.find(kHEVCFmtpProfileId);
-  if (profile_it == params.end())
-    return H265ProfileId::kMain;
+  if (profile_it == params.end()) return H265ProfileId::kMain;
   const std::string& profile_str = profile_it->second;
   return StringToH265Profile(profile_str);
 }

--- a/src/win/mediautils.h
+++ b/src/win/mediautils.h
@@ -6,6 +6,7 @@
 #define OWT_BASE_MEDIAUTILS_H_
 
 #include <string>
+
 #include "absl/types/optional.h"
 #include "api/video_codecs/sdp_video_format.h"
 #include "src/win/commontypes.h"
@@ -168,10 +169,8 @@ class MediaUtils {
   static AudioCodec GetAudioCodecFromString(const std::string& codec_name);
   static VideoCodec GetVideoCodecFromString(const std::string& codec_name);
   static absl::optional<unsigned int> GetH264TemporalLayers();
-  static bool GetH264TemporalInfo(uint8_t* buffer,
-                                  size_t buffer_length,
-                                  int& temporal_id,
-                                  int& priority_id,
+  static bool GetH264TemporalInfo(uint8_t* buffer, size_t buffer_length,
+                                  int& temporal_id, int& priority_id,
                                   bool& is_idr);
   static absl::optional<AV1Profile> ParseSdpForAV1Profile(
       const webrtc::SdpVideoFormat::Parameters& params);

--- a/src/win/msdkcommon.h
+++ b/src/win/msdkcommon.h
@@ -5,12 +5,12 @@
 #ifndef OWT_BASE_WIN_MSDKCOMMON_H_
 #define OWT_BASE_WIN_MSDKCOMMON_H_
 
-#include <mutex>
-
 #include <mfxcommon.h>
 #include <mfxdefs.h>
 #include <mfxplugin++.h>
 #include <mfxvideo++.h>
+
+#include <mutex>
 
 #ifdef WEBRTC_WIN
 #include <tchar.h>

--- a/src/win/msdkvideobase.cc
+++ b/src/win/msdkvideobase.cc
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "msdkvideobase.h"
+
 #include "atlbase.h"
 #include "d3d11_allocator.h"
 #include "d3d_allocator.h"
 #include "mfxdefs.h"
-
 #include "rtc_base/logging.h"
 
 namespace owt {
@@ -19,8 +19,7 @@ MSDKFactory* MSDKFactory::singleton = nullptr;
 static bool AreGuidsEqual(const mfxPluginUID* guid_first,
                           const mfxPluginUID* guid_second) {
   for (size_t i = 0; i < sizeof(mfxPluginUID); i++) {
-    if (guid_first->Data[i] != guid_second->Data[i])
-      return false;
+    if (guid_first->Data[i] != guid_second->Data[i]) return false;
   }
   return true;
 }
@@ -50,9 +49,7 @@ void MSDKFactory::MFETimeout(uint32_t timeout) {
   mfe_timeout = timeout < 100 ? timeout : 100;
 }
 
-uint32_t MSDKFactory::MFETimeout() {
-  return mfe_timeout;
-}
+uint32_t MSDKFactory::MFETimeout() { return mfe_timeout; }
 
 MSDKFactory* MSDKFactory::Get() {
   std::lock_guard<std::mutex> lock(get_singleton_mutex);
@@ -72,13 +69,11 @@ MSDKFactory* MSDKFactory::Get() {
 MFXVideoSession* MSDKFactory::InternalCreateSession(bool use_d3d11) {
   mfxStatus sts = MFX_ERR_NONE;
   mfxIMPL impl = MFX_IMPL_HARDWARE_ANY;
-  if (use_d3d11)
-    impl |= MFX_IMPL_VIA_D3D11;
+  if (use_d3d11) impl |= MFX_IMPL_VIA_D3D11;
   mfxVersion version = {{3, 1}};
 
   MFXVideoSession* session = new MFXVideoSession();
-  if (!session)
-    return nullptr;
+  if (!session) return nullptr;
 
   sts = session->Init(impl, &version);
   if (sts != MFX_ERR_NONE) {
@@ -118,8 +113,7 @@ void MSDKFactory::DestroySession(MFXVideoSession* session) {
   }
 }
 
-bool MSDKFactory::LoadDecoderPlugin(uint32_t codec_id,
-                                    MFXVideoSession* session,
+bool MSDKFactory::LoadDecoderPlugin(uint32_t codec_id, MFXVideoSession* session,
                                     mfxPluginUID* plugin_id) {
   mfxStatus sts = MFX_ERR_NONE;
 
@@ -155,8 +149,7 @@ bool MSDKFactory::LoadDecoderPlugin(uint32_t codec_id,
   return true;
 }
 
-bool MSDKFactory::LoadEncoderPlugin(uint32_t codec_id,
-                                    MFXVideoSession* session,
+bool MSDKFactory::LoadEncoderPlugin(uint32_t codec_id, MFXVideoSession* session,
                                     mfxPluginUID* plugin_id) {
   mfxStatus sts = MFX_ERR_NONE;
   switch (codec_id) {
@@ -184,8 +177,7 @@ void MSDKFactory::UnloadMSDKPlugin(MFXVideoSession* session,
 
 bool MSDKFactory::QueryPlatform(MFXVideoSession* session,
                                 mfxPlatform* platform) {
-  if (!session || !platform)
-    return false;
+  if (!session || !platform) return false;
 
   mfxStatus sts = MFX_ERR_NONE;
   sts = MFXVideoCORE_QueryPlatform(*session, platform);

--- a/src/win/msdkvideobase.h
+++ b/src/win/msdkvideobase.h
@@ -14,8 +14,10 @@
 #include <mfxplugin++.h>
 #include <mfxvideo++.h>
 #include <mfxvp8.h>
+
 #include <memory>
 #include <mutex>
+
 #include "msdkcommon.h"
 #include "src/win/d3d11_allocator.h"
 #include "src/win/d3d_allocator.h"
@@ -38,11 +40,9 @@ class MSDKFactory {
   MFXVideoSession* GetMainSession();
 
   bool QueryPlatform(MFXVideoSession* session, mfxPlatform* platform);
-  bool LoadDecoderPlugin(uint32_t codec_id,
-                         MFXVideoSession* session,
+  bool LoadDecoderPlugin(uint32_t codec_id, MFXVideoSession* session,
                          mfxPluginUID* plugin_id);
-  bool LoadEncoderPlugin(uint32_t codec_id,
-                         MFXVideoSession* session,
+  bool LoadEncoderPlugin(uint32_t codec_id, MFXVideoSession* session,
                          mfxPluginUID* plugin_id);
   void UnloadMSDKPlugin(MFXVideoSession* session, mfxPluginUID* plugin_id);
 

--- a/src/win/msdkvideodecoder.cc
+++ b/src/win/msdkvideodecoder.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/msdkvideodecoder.h"
+
 #include "api/scoped_refptr.h"
 #include "mfxadapter.h"
 #include "msdkvideobase.h"
@@ -85,8 +86,7 @@ bool MSDKVideoDecoder::CreateD3D11Device() {
   mfxU32 num_adapters;
   sts = MFXQueryAdaptersNumber(&num_adapters);
 
-  if (sts != MFX_ERR_NONE)
-    return false;
+  if (sts != MFX_ERR_NONE) return false;
 
   std::vector<mfxAdapterInfo> display_data(num_adapters);
   mfxAdaptersInfo adapters = {display_data.data(), mfxU32(display_data.size()),
@@ -185,8 +185,7 @@ int32_t MSDKVideoDecoder::InitDecodeOnCodecThread() {
   uint32_t codec_id = MFX_CODEC_AVC;
 
   if (inited_) {
-    if (m_pmfx_dec_)
-      m_pmfx_dec_->Close();
+    if (m_pmfx_dec_) m_pmfx_dec_->Close();
     MSDK_SAFE_DELETE_ARRAY(m_pinput_surfaces_);
 
     if (m_pmfx_allocator_) {
@@ -250,8 +249,7 @@ int32_t MSDKVideoDecoder::InitDecodeOnCodecThread() {
 }
 
 int32_t MSDKVideoDecoder::Decode(const webrtc::EncodedImage& inputImage,
-                                 bool missingFrames,
-                                 int64_t renderTimeMs) {
+                                 bool missingFrames, int64_t renderTimeMs) {
   mfxStatus sts = MFX_ERR_NONE;
   mfxFrameSurface1* pOutputSurface = nullptr;
 
@@ -440,8 +438,7 @@ mfxStatus MSDKVideoDecoder::ExtendMfxBitstream(mfxBitstream* pBitstream,
 }
 
 void MSDKVideoDecoder::ReadFromInputStream(mfxBitstream* pBitstream,
-                                           const uint8_t* data,
-                                           size_t len) {
+                                           const uint8_t* data, size_t len) {
   if (m_mfx_bs_.MaxLength < len) {
     // Remaining BS size is not enough to hold current image, we enlarge it the
     // gap*2.

--- a/src/win/msdkvideodecoder.h
+++ b/src/win/msdkvideodecoder.h
@@ -9,9 +9,11 @@
 #include <d3d11.h>
 #include <dxgi1_2.h>
 #include <dxva2api.h>
+
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "media/base/codec.h"
 #include "modules/video_coding/include/video_codec_interface.h"
 #include "rtc_base/checks.h"
@@ -57,8 +59,7 @@ class MSDKVideoDecoder : public webrtc::VideoDecoder {
 
   bool Configure(const Settings& settings) override;
 
-  int32_t Decode(const webrtc::EncodedImage& inputImage,
-                 bool missingFrames,
+  int32_t Decode(const webrtc::EncodedImage& inputImage, bool missingFrames,
                  int64_t renderTimeMs = -1) override;
 
   int32_t RegisterDecodeCompleteCallback(
@@ -76,8 +77,7 @@ class MSDKVideoDecoder : public webrtc::VideoDecoder {
 
   mfxStatus ExtendMfxBitstream(mfxBitstream* pBitstream, mfxU32 nSize);
   void WipeMfxBitstream(mfxBitstream* pBitstream);
-  void ReadFromInputStream(mfxBitstream* pBitstream,
-                           const uint8_t* data,
+  void ReadFromInputStream(mfxBitstream* pBitstream, const uint8_t* data,
                            size_t len);
   mfxU16 DecGetFreeSurface(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize);
   mfxU16 DecGetFreeSurfaceIndex(mfxFrameSurface1* pSurfacesPool,

--- a/src/win/msdkvideodecoderfactory.cc
+++ b/src/win/msdkvideodecoderfactory.cc
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/msdkvideodecoderfactory.h"
+
 #include <vector>
+
 #include "absl/strings/match.h"
 #include "media/base/codec.h"
 #include "modules/video_coding/codecs/av1/libaom_av1_decoder.h"

--- a/src/win/msdkvideoencoder.cc
+++ b/src/win/msdkvideoencoder.cc
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/msdkvideoencoder.h"
+
 #include <string>
 #include <vector>
+
 #include "absl/algorithm/container.h"
 #include "common_video/h264/h264_common.h"
 #include "libyuv/convert_from.h"
@@ -82,8 +84,7 @@ MSDKVideoEncoder::~MSDKVideoEncoder() {
 }
 
 int MSDKVideoEncoder::InitEncode(const webrtc::VideoCodec* codec_settings,
-                                 int number_of_cores,
-                                 size_t max_payload_size) {
+                                 int number_of_cores, size_t max_payload_size) {
   RTC_DCHECK(codec_settings);
 
   width_ = codec_settings->width;
@@ -102,8 +103,7 @@ int MSDKVideoEncoder::InitEncode(const webrtc::VideoCodec* codec_settings,
       });
 }
 
-mfxStatus MSDKConvertFrameRate(mfxF64 dFrameRate,
-                               mfxU32* pnFrameRateExtN,
+mfxStatus MSDKConvertFrameRate(mfxF64 dFrameRate, mfxU32* pnFrameRateExtN,
                                mfxU32* pnFrameRateExtD) {
   mfxU32 fr;
   fr = (mfxU32)(dFrameRate + 0.5);
@@ -129,8 +129,7 @@ mfxStatus MSDKConvertFrameRate(mfxF64 dFrameRate,
 }
 
 int MSDKVideoEncoder::InitEncodeOnEncoderThread(
-    const webrtc::VideoCodec* codec_settings,
-    int number_of_cores,
+    const webrtc::VideoCodec* codec_settings, int number_of_cores,
     size_t max_payload_size) {
   mfxStatus sts;
   RTC_LOG(LS_INFO) << "InitEncodeOnEncoderThread: maxBitrate:"
@@ -269,8 +268,7 @@ int MSDKVideoEncoder::InitEncodeOnEncoderThread(
       std::min(static_cast<int>(
                    codec_settings->simulcastStream[0].numberOfTemporalLayers),
                3);
-  if (num_temporal_layers_ == 0)
-    num_temporal_layers_ = 1;
+  if (num_temporal_layers_ == 0) num_temporal_layers_ = 1;
 
   if (!m_enc_ext_params_.empty()) {
     m_mfx_enc_params_.ExtParam =
@@ -353,8 +351,7 @@ mfxU16 MSDKVideoEncoder::MSDKGetFreeSurface(mfxFrameSurface1* pSurfacesPool,
 }
 
 mfxU16 MSDKVideoEncoder::MSDKGetFreeSurfaceIndex(
-    mfxFrameSurface1* pSurfacesPool,
-    mfxU16 nPoolSize) {
+    mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize) {
   if (pSurfacesPool) {
     for (mfxU16 i = 0; i < nPoolSize; i++) {
       if (0 == pSurfacesPool[i].Data.Locked) {
@@ -652,8 +649,7 @@ int MSDKVideoEncoder::Release() {
     }
     m_mfx_session_ = nullptr;
   }
-  if (m_pmfx_allocator_)
-    m_pmfx_allocator_->Close();
+  if (m_pmfx_allocator_) m_pmfx_allocator_->Close();
   m_pmfx_allocator_.reset();
 
   inited_ = false;
@@ -662,8 +658,7 @@ int MSDKVideoEncoder::Release() {
   return WEBRTC_VIDEO_CODEC_OK;
 }
 
-int32_t MSDKVideoEncoder::NextNaluPosition(uint8_t* buffer,
-                                           size_t buffer_size,
+int32_t MSDKVideoEncoder::NextNaluPosition(uint8_t* buffer, size_t buffer_size,
                                            uint8_t* sc_length) {
   if (buffer_size < NAL_SC_LENGTH) {
     return -1;

--- a/src/win/msdkvideoencoder.h
+++ b/src/win/msdkvideoencoder.h
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <memory>
 #include <vector>
+
 #include "api/video_codecs/video_codec.h"
 #include "api/video_codecs/video_encoder.h"
 #include "base_allocator.h"
@@ -37,8 +38,7 @@ class MSDKVideoEncoder : public webrtc::VideoEncoder {
   virtual ~MSDKVideoEncoder();
 
   static std::unique_ptr<MSDKVideoEncoder> Create(cricket::VideoCodec format);
-  int InitEncode(const webrtc::VideoCodec* codec_settings,
-                 int number_of_cores,
+  int InitEncode(const webrtc::VideoCodec* codec_settings, int number_of_cores,
                  size_t max_payload_size) override;
   int Encode(const webrtc::VideoFrame& input_image,
              const std::vector<webrtc::VideoFrameType>* frame_types) override;
@@ -53,10 +53,8 @@ class MSDKVideoEncoder : public webrtc::VideoEncoder {
 
  private:
   int InitEncodeOnEncoderThread(const webrtc::VideoCodec* codec_settings,
-                                int number_of_cores,
-                                size_t max_payload_size);
-  int32_t NextNaluPosition(uint8_t* buffer,
-                           size_t buffer_size,
+                                int number_of_cores, size_t max_payload_size);
+  int32_t NextNaluPosition(uint8_t* buffer, size_t buffer_size,
                            uint8_t* sc_length);
   mfxU16 MSDKGetFreeSurface(mfxFrameSurface1* pSurfacesPool, mfxU16 nPoolSize);
   mfxU16 MSDKGetFreeSurfaceIndex(mfxFrameSurface1* pSurfacesPool,

--- a/src/win/msdkvideoencoderfactory.cc
+++ b/src/win/msdkvideoencoderfactory.cc
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "src/win/msdkvideoencoderfactory.h"
+
 #include <string>
+
 #include "absl/strings/match.h"
 #include "modules/video_coding/codecs/av1/libaom_av1_encoder.h"
 #include "modules/video_coding/codecs/h264/include/h264.h"

--- a/src/win/msdkvideoencoderfactory.h
+++ b/src/win/msdkvideoencoderfactory.h
@@ -6,6 +6,7 @@
 #define OWT_BASE_WIN_MSDKVIDEOENCODER_FACTORY_H_
 
 #include <vector>
+
 #include "api/video/video_codec_type.h"
 #include "api/video_codecs/sdp_video_format.h"
 #include "api/video_codecs/video_encoder.h"

--- a/src/win/sysmem_allocator.cc
+++ b/src/win/sysmem_allocator.cc
@@ -50,17 +50,14 @@ namespace base {
 SysMemFrameAllocator::SysMemFrameAllocator()
     : m_pBufferAllocator(0), m_bOwnBufferAllocator(false) {}
 
-SysMemFrameAllocator::~SysMemFrameAllocator() {
-  Close();
-}
+SysMemFrameAllocator::~SysMemFrameAllocator() { Close(); }
 
 mfxStatus SysMemFrameAllocator::Init(mfxAllocatorParams* pParams) {
   // Check if any params passed from application
   if (pParams) {
     SysMemAllocatorParams* pSysMemParams = 0;
     pSysMemParams = static_cast<SysMemAllocatorParams*>(pParams);
-    if (!pSysMemParams)
-      return MFX_ERR_NOT_INITIALIZED;
+    if (!pSysMemParams) return MFX_ERR_NOT_INITIALIZED;
 
     m_pBufferAllocator = pSysMemParams->pBufferAllocator;
     m_bOwnBufferAllocator = false;
@@ -69,8 +66,7 @@ mfxStatus SysMemFrameAllocator::Init(mfxAllocatorParams* pParams) {
   // If buffer allocator wasn't passed from application create own
   if (!m_pBufferAllocator) {
     m_pBufferAllocator = new SysMemBufferAllocator;
-    if (!m_pBufferAllocator)
-      return MFX_ERR_MEMORY_ALLOC;
+    if (!m_pBufferAllocator) return MFX_ERR_MEMORY_ALLOC;
 
     m_bOwnBufferAllocator = true;
   }
@@ -89,22 +85,18 @@ mfxStatus SysMemFrameAllocator::Close() {
 }
 
 mfxStatus SysMemFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData* ptr) {
-  if (!m_pBufferAllocator)
-    return MFX_ERR_NOT_INITIALIZED;
+  if (!m_pBufferAllocator) return MFX_ERR_NOT_INITIALIZED;
 
-  if (!ptr)
-    return MFX_ERR_NULL_PTR;
+  if (!ptr) return MFX_ERR_NULL_PTR;
 
   // If allocator uses pointers instead of mids, no further action is required
-  if (!mid && ptr->Y)
-    return MFX_ERR_NONE;
+  if (!mid && ptr->Y) return MFX_ERR_NONE;
 
   sFrame* fs = 0;
   mfxStatus sts =
       m_pBufferAllocator->Lock(m_pBufferAllocator->pthis, mid, (mfxU8**)&fs);
 
-  if (MFX_ERR_NONE != sts)
-    return sts;
+  if (MFX_ERR_NONE != sts) return sts;
 
   if (ID_FRAME != fs->id) {
     m_pBufferAllocator->Unlock(m_pBufferAllocator->pthis, mid);
@@ -183,17 +175,14 @@ mfxStatus SysMemFrameAllocator::LockFrame(mfxMemId mid, mfxFrameData* ptr) {
 }
 
 mfxStatus SysMemFrameAllocator::UnlockFrame(mfxMemId mid, mfxFrameData* ptr) {
-  if (!m_pBufferAllocator)
-    return MFX_ERR_NOT_INITIALIZED;
+  if (!m_pBufferAllocator) return MFX_ERR_NOT_INITIALIZED;
 
   // If allocator uses pointers instead of mids, no further action is required
-  if (!mid && ptr->Y)
-    return MFX_ERR_NONE;
+  if (!mid && ptr->Y) return MFX_ERR_NONE;
 
   mfxStatus sts = m_pBufferAllocator->Unlock(m_pBufferAllocator->pthis, mid);
 
-  if (MFX_ERR_NONE != sts)
-    return sts;
+  if (MFX_ERR_NONE != sts) return sts;
 
   if (NULL != ptr) {
     ptr->Pitch = 0;
@@ -213,8 +202,7 @@ mfxStatus SysMemFrameAllocator::GetFrameHDL(mfxMemId mid, mfxHDL* handle) {
 mfxStatus SysMemFrameAllocator::CheckRequestType(
     mfxFrameAllocRequest* request) {
   mfxStatus sts = BaseFrameAllocator::CheckRequestType(request);
-  if (MFX_ERR_NONE != sts)
-    return sts;
+  if (MFX_ERR_NONE != sts) return sts;
 
   if ((request->Type & MFX_MEMTYPE_SYSTEM_MEMORY) != 0)
     return MFX_ERR_NONE;
@@ -224,8 +212,7 @@ mfxStatus SysMemFrameAllocator::CheckRequestType(
 
 mfxStatus SysMemFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
                                           mfxFrameAllocResponse* response) {
-  if (!m_pBufferAllocator)
-    return MFX_ERR_NOT_INITIALIZED;
+  if (!m_pBufferAllocator) return MFX_ERR_NOT_INITIALIZED;
 
   mfxU32 numAllocated = 0;
 
@@ -277,8 +264,7 @@ mfxStatus SysMemFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
   }
 
   safe_array<mfxMemId> mids(new mfxMemId[request->NumFrameSuggested]);
-  if (!mids.get())
-    return MFX_ERR_MEMORY_ALLOC;
+  if (!mids.get()) return MFX_ERR_MEMORY_ALLOC;
 
   // Allocate frames
   for (numAllocated = 0; numAllocated < request->NumFrameSuggested;
@@ -287,15 +273,13 @@ mfxStatus SysMemFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
         m_pBufferAllocator->pthis, nbytes + MSDK_ALIGN32(sizeof(sFrame)),
         request->Type, &(mids.get()[numAllocated]));
 
-    if (MFX_ERR_NONE != sts)
-      break;
+    if (MFX_ERR_NONE != sts) break;
 
     sFrame* fs;
     sts = m_pBufferAllocator->Lock(m_pBufferAllocator->pthis,
                                    mids.get()[numAllocated], (mfxU8**)&fs);
 
-    if (MFX_ERR_NONE != sts)
-      break;
+    if (MFX_ERR_NONE != sts) break;
 
     fs->id = ID_FRAME;
     fs->info = request->Info;
@@ -316,11 +300,9 @@ mfxStatus SysMemFrameAllocator::AllocImpl(mfxFrameAllocRequest* request,
 
 mfxStatus SysMemFrameAllocator::ReleaseResponse(
     mfxFrameAllocResponse* response) {
-  if (!response)
-    return MFX_ERR_NULL_PTR;
+  if (!response) return MFX_ERR_NULL_PTR;
 
-  if (!m_pBufferAllocator)
-    return MFX_ERR_NOT_INITIALIZED;
+  if (!m_pBufferAllocator) return MFX_ERR_NOT_INITIALIZED;
 
   mfxStatus sts = MFX_ERR_NONE;
 
@@ -329,8 +311,7 @@ mfxStatus SysMemFrameAllocator::ReleaseResponse(
       if (response->mids[i]) {
         sts = m_pBufferAllocator->Free(m_pBufferAllocator->pthis,
                                        response->mids[i]);
-        if (MFX_ERR_NONE != sts)
-          return sts;
+        if (MFX_ERR_NONE != sts) return sts;
       }
     }
   }
@@ -345,20 +326,16 @@ SysMemBufferAllocator::SysMemBufferAllocator() {}
 
 SysMemBufferAllocator::~SysMemBufferAllocator() {}
 
-mfxStatus SysMemBufferAllocator::AllocBuffer(mfxU32 nbytes,
-                                             mfxU16 type,
+mfxStatus SysMemBufferAllocator::AllocBuffer(mfxU32 nbytes, mfxU16 type,
                                              mfxMemId* mid) {
-  if (!mid)
-    return MFX_ERR_NULL_PTR;
+  if (!mid) return MFX_ERR_NULL_PTR;
 
-  if (0 == (type & MFX_MEMTYPE_SYSTEM_MEMORY))
-    return MFX_ERR_UNSUPPORTED;
+  if (0 == (type & MFX_MEMTYPE_SYSTEM_MEMORY)) return MFX_ERR_UNSUPPORTED;
 
   mfxU32 header_size = MSDK_ALIGN32(sizeof(sBuffer));
   mfxU8* buffer_ptr = (mfxU8*)calloc(header_size + nbytes + 32, 1);
 
-  if (!buffer_ptr)
-    return MFX_ERR_MEMORY_ALLOC;
+  if (!buffer_ptr) return MFX_ERR_MEMORY_ALLOC;
 
   sBuffer* bs = (sBuffer*)buffer_ptr;
   bs->id = ID_BUFFER;
@@ -369,15 +346,12 @@ mfxStatus SysMemBufferAllocator::AllocBuffer(mfxU32 nbytes,
 }
 
 mfxStatus SysMemBufferAllocator::LockBuffer(mfxMemId mid, mfxU8** ptr) {
-  if (!ptr)
-    return MFX_ERR_NULL_PTR;
+  if (!ptr) return MFX_ERR_NULL_PTR;
 
   sBuffer* bs = (sBuffer*)mid;
 
-  if (!bs)
-    return MFX_ERR_INVALID_HANDLE;
-  if (ID_BUFFER != bs->id)
-    return MFX_ERR_INVALID_HANDLE;
+  if (!bs) return MFX_ERR_INVALID_HANDLE;
+  if (ID_BUFFER != bs->id) return MFX_ERR_INVALID_HANDLE;
 
   *ptr = (mfxU8*)((size_t)((mfxU8*)bs + MSDK_ALIGN32(sizeof(sBuffer)) + 31) &
                   (~((size_t)31)));
@@ -387,16 +361,14 @@ mfxStatus SysMemBufferAllocator::LockBuffer(mfxMemId mid, mfxU8** ptr) {
 mfxStatus SysMemBufferAllocator::UnlockBuffer(mfxMemId mid) {
   sBuffer* bs = (sBuffer*)mid;
 
-  if (!bs || ID_BUFFER != bs->id)
-    return MFX_ERR_INVALID_HANDLE;
+  if (!bs || ID_BUFFER != bs->id) return MFX_ERR_INVALID_HANDLE;
 
   return MFX_ERR_NONE;
 }
 
 mfxStatus SysMemBufferAllocator::FreeBuffer(mfxMemId mid) {
   sBuffer* bs = (sBuffer*)mid;
-  if (!bs || ID_BUFFER != bs->id)
-    return MFX_ERR_INVALID_HANDLE;
+  if (!bs || ID_BUFFER != bs->id) return MFX_ERR_INVALID_HANDLE;
 
   free(bs);
   return MFX_ERR_NONE;

--- a/src/win/sysmem_allocator.h
+++ b/src/win/sysmem_allocator.h
@@ -41,6 +41,7 @@ https://software.intel.com/en-us/media-client-solutions-support.
 #define __SYSMEM_ALLOCATOR_H__
 
 #include <stdlib.h>
+
 #include "base_allocator.h"
 
 namespace owt {


### PR DESCRIPTION
1. If the candidate or session description is empty or invalid, crash will happened.
2. Format the source with google style.