### PR TITLE
Added bundle_policy to peer_connection config

### DIFF
--- a/src/rtc_peerconnection_impl.cc
+++ b/src/rtc_peerconnection_impl.cc
@@ -39,6 +39,16 @@ static std::map<libwebrtc::CandidateNetworkPolicy,
         {libwebrtc::CandidateNetworkPolicy::kCandidateNetworkPolicyLowCost,
          webrtc::PeerConnectionInterface::kCandidateNetworkPolicyLowCost}};
 
+static std::map<libwebrtc::BundlePolicy,
+  webrtc::PeerConnectionInterface::BundlePolicy>
+    bundle_policy_map = {
+        {libwebrtc::kBundlePolicyBalanced,
+        webrtc::PeerConnectionInterface::kBundlePolicyBalanced},
+        {libwebrtc::kBundlePolicyMaxBundle,
+        webrtc::PeerConnectionInterface::kBundlePolicyMaxBundle},
+        {libwebrtc::kBundlePolicyMaxCompat,
+        webrtc::PeerConnectionInterface::kBundlePolicyMaxCompat}};
+
 static std::map<libwebrtc::IceTransportsType,
                 webrtc::PeerConnectionInterface::IceTransportsType>
     ice_transport_type_map = {{libwebrtc::IceTransportsType::kAll,
@@ -382,7 +392,7 @@ bool RTCPeerConnectionImpl::Initialize() {
       config.servers.push_back(server);
     }
   }
-
+  config.bundle_policy = bundle_policy_map[configuration_.bundle_policy];
   config.sdp_semantics = sdp_semantics_map[configuration_.sdp_semantics];
   config.candidate_network_policy =
       candidate_network_policy_map[configuration_.candidate_network_policy];


### PR DESCRIPTION
Previously, the `bundle_policy` passed using the configuration object wasn't used to instantiate the config in `rtc_peer_connection_impl.cc`. 

This caused candidate generation subsequent tracks even if bundle policy was set to `MaxBundle` in my case.

I have added the mapping from `libwebrtc::BundlePolicy` to `webrtc::PeerConnectionInterface::BundlePolicy` and added the bundle_policy to the config object.