### PR TITLE
Add wmf h265 support

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -206,6 +206,25 @@ rtc_shared_library("libwebrtc") {
     ]
   }
 
+  # WMF H.265 support (Windows without Intel Media SDK)
+  if (is_win && !libwebrtc_intel_media_sdk && rtc_use_h265) {
+    sources += [
+      "src/win/wmf_h265_encoder.cc",
+      "src/win/wmf_h265_encoder.h",
+      "src/win/wmf_h265_decoder.cc",
+      "src/win/wmf_h265_decoder.h",
+      "src/win/wmf_h265_factory.cc",
+      "src/win/wmf_h265_factory.h",
+    ]
+    libs += [
+      "mfplat.lib",
+      "mfuuid.lib",
+      "mf.lib",
+      "d3d11.lib",
+      "dxgi.lib",
+    ]
+  }
+
   if (is_win && is_clang) {
     cflags = [
       "-Wno-microsoft-extra-qualification",
@@ -226,6 +245,7 @@ rtc_shared_library("libwebrtc") {
     "../api/video:video_frame",
     "../api/video_codecs:builtin_video_decoder_factory",
     "../api/video_codecs:builtin_video_encoder_factory",
+    "../common_video",
     "../media:rtc_audio_video",
     "../media:rtc_internal_video_codecs",
     "../media:rtc_media",

--- a/src/rtc_peerconnection_factory_impl.cc
+++ b/src/rtc_peerconnection_factory_impl.cc
@@ -18,6 +18,8 @@
 #include "src/win/mediacapabilities.h"
 #include "src/win/msdkvideodecoderfactory.h"
 #include "src/win/msdkvideoencoderfactory.h"
+#elif defined(WEBRTC_WIN) && defined(RTC_ENABLE_H265)
+#include "src/win/wmf_h265_factory.h"
 #endif
 #if defined(WEBRTC_IOS)
 #include "engine/sdk/objc/Framework/Classes/videotoolboxvideocodecfactory.h"
@@ -83,6 +85,11 @@ bool RTCPeerConnectionFactoryImpl::Initialize() {
         webrtc::CreateBuiltinAudioDecoderFactory(),
 #if defined(USE_INTEL_MEDIA_SDK)
         CreateIntelVideoEncoderFactory(), CreateIntelVideoDecoderFactory(),
+#elif defined(WEBRTC_WIN) && defined(RTC_ENABLE_H265)
+        webrtc::CreateWmfH265EncoderFactory(
+            webrtc::CreateBuiltinVideoEncoderFactory()),
+        webrtc::CreateWmfH265DecoderFactory(
+            webrtc::CreateBuiltinVideoDecoderFactory()),
 #else
         webrtc::CreateBuiltinVideoEncoderFactory(),
         webrtc::CreateBuiltinVideoDecoderFactory(),

--- a/src/win/wmf_h265_decoder.cc
+++ b/src/win/wmf_h265_decoder.cc
@@ -1,0 +1,529 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "src/win/wmf_h265_decoder.h"
+
+#include <mftransform.h>
+
+#include <algorithm>
+
+#include "api/video/i420_buffer.h"
+#include "api/video/video_frame_buffer.h"
+#include "media/base/media_constants.h"
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/string_utils.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "mfuuid.lib")
+#pragma comment(lib, "mf.lib")
+
+namespace webrtc {
+
+WmfH265Decoder::WmfH265Decoder() {}
+
+WmfH265Decoder::~WmfH265Decoder() {
+  Release();
+}
+
+std::unique_ptr<WmfH265Decoder> WmfH265Decoder::Create() {
+  if (!IsSupported()) {
+    RTC_LOG(LS_ERROR) << "WMF H.265 decoder is not supported on this system.";
+    return nullptr;
+  }
+  return std::make_unique<WmfH265Decoder>();
+}
+
+bool WmfH265Decoder::IsSupported() {
+  // Ensure COM is initialized on this thread (MF requires it)
+  HRESULT com_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  bool should_uninit_com = SUCCEEDED(com_hr);
+
+  HRESULT hr = MFStartup(MF_VERSION);
+  if (FAILED(hr)) {
+    if (should_uninit_com) CoUninitialize();
+    return false;
+  }
+
+  // Enumerate HEVC decoders
+  MFT_REGISTER_TYPE_INFO input_type = {MFMediaType_Video,
+                                       MFVideoFormat_HEVC};
+  IMFActivate** activate = nullptr;
+  UINT32 count = 0;
+
+  hr = MFTEnumEx(MFT_CATEGORY_VIDEO_DECODER,
+                 MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_ASYNCMFT |
+                     MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+                 &input_type, nullptr, &activate, &count);
+
+  bool supported = SUCCEEDED(hr) && count > 0;
+
+  if (activate) {
+    for (UINT32 i = 0; i < count; i++) {
+      activate[i]->Release();
+    }
+    CoTaskMemFree(activate);
+  }
+
+  MFShutdown();
+  if (should_uninit_com) CoUninitialize();
+  return supported;
+}
+
+HRESULT WmfH265Decoder::InitMediaFoundation() {
+  // Ensure COM is initialized on the calling thread
+  HRESULT com_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  if (SUCCEEDED(com_hr)) {
+    com_initialized_ = true;
+  } else if (com_hr != RPC_E_CHANGED_MODE) {
+    RTC_LOG(LS_ERROR) << "CoInitializeEx failed: " << static_cast<int>(com_hr);
+    return com_hr;
+  }
+
+  HRESULT hr = MFStartup(MF_VERSION);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFStartup failed: " << static_cast<int>(hr);
+    if (com_initialized_) {
+      CoUninitialize();
+      com_initialized_ = false;
+    }
+    return hr;
+  }
+  mf_started_ = true;
+  return S_OK;
+}
+
+HRESULT WmfH265Decoder::CreateHEVCDecoder() {
+  MFT_REGISTER_TYPE_INFO input_type = {MFMediaType_Video,
+                                       MFVideoFormat_HEVC};
+  IMFActivate** activate = nullptr;
+  UINT32 count = 0;
+
+  HRESULT hr = MFTEnumEx(
+      MFT_CATEGORY_VIDEO_DECODER,
+      MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_ASYNCMFT |
+          MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+      &input_type, nullptr, &activate, &count);
+
+  if (FAILED(hr) || count == 0) {
+    RTC_LOG(LS_ERROR) << "No HEVC decoder MFT found. hr=" << static_cast<int>(hr);
+    if (activate) CoTaskMemFree(activate);
+    return E_FAIL;
+  }
+
+  // Log available decoders
+  for (UINT32 i = 0; i < count; i++) {
+    LPWSTR friendly_name = nullptr;
+    UINT32 name_len = 0;
+    activate[i]->GetAllocatedString(MFT_FRIENDLY_NAME_Attribute,
+                                    &friendly_name, &name_len);
+    if (friendly_name) {
+      RTC_LOG(LS_INFO) << "Found HEVC decoder: "
+                       << webrtc::ToUtf8(friendly_name, name_len);
+      CoTaskMemFree(friendly_name);
+    }
+  }
+
+  // Activate the first (highest priority) decoder
+  hr = activate[0]->ActivateObject(IID_PPV_ARGS(&decoder_));
+
+  for (UINT32 i = 0; i < count; i++) {
+    activate[i]->Release();
+  }
+  CoTaskMemFree(activate);
+
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to activate HEVC decoder MFT: " << static_cast<int>(hr);
+    return hr;
+  }
+
+  // Set low-latency mode if supported
+  Microsoft::WRL::ComPtr<IMFAttributes> attributes;
+  hr = decoder_->GetAttributes(&attributes);
+  if (SUCCEEDED(hr)) {
+    attributes->SetUINT32(MF_LOW_LATENCY, TRUE);
+  }
+
+  RTC_LOG(LS_INFO) << "HEVC decoder MFT activated successfully.";
+  return S_OK;
+}
+
+HRESULT WmfH265Decoder::ConfigureInputType() {
+  HRESULT hr = MFCreateMediaType(&input_type_);
+  if (FAILED(hr)) return hr;
+
+  input_type_->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+  input_type_->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_HEVC);
+
+  if (width_ > 0 && height_ > 0) {
+    MFSetAttributeSize(input_type_.Get(), MF_MT_FRAME_SIZE, width_, height_);
+  }
+
+  hr = decoder_->SetInputType(input_stream_id_, input_type_.Get(), 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetInputType failed: " << static_cast<int>(hr);
+    return hr;
+  }
+
+  return S_OK;
+}
+
+HRESULT WmfH265Decoder::ConfigureOutputType() {
+  // Find NV12 output type
+  DWORD type_index = 0;
+  bool found_nv12 = false;
+
+  while (true) {
+    Microsoft::WRL::ComPtr<IMFMediaType> available_type;
+    HRESULT hr = decoder_->GetOutputAvailableType(output_stream_id_,
+                                                   type_index, &available_type);
+    if (FAILED(hr)) break;
+
+    GUID subtype;
+    hr = available_type->GetGUID(MF_MT_SUBTYPE, &subtype);
+    if (SUCCEEDED(hr) && (subtype == MFVideoFormat_NV12 ||
+                          subtype == MFVideoFormat_I420 ||
+                          subtype == MFVideoFormat_IYUV)) {
+      output_type_ = available_type;
+      found_nv12 = true;
+
+      hr = decoder_->SetOutputType(output_stream_id_, output_type_.Get(), 0);
+      if (SUCCEEDED(hr)) {
+        RTC_LOG(LS_INFO) << "HEVC decoder output type set (type index "
+                         << type_index << ")";
+        break;
+      }
+    }
+    type_index++;
+  }
+
+  if (!found_nv12) {
+    RTC_LOG(LS_ERROR) << "Could not find suitable output type for HEVC decoder";
+    return E_FAIL;
+  }
+
+  return S_OK;
+}
+
+bool WmfH265Decoder::Configure(const Settings& settings) {
+  Release();
+
+  width_ = settings.codec_type() == kVideoCodecH265 ? settings.max_render_resolution().Width() : 0;
+  height_ = settings.codec_type() == kVideoCodecH265 ? settings.max_render_resolution().Height() : 0;
+
+  HRESULT hr = InitMediaFoundation();
+  if (FAILED(hr)) return false;
+
+  hr = CreateHEVCDecoder();
+  if (FAILED(hr)) return false;
+
+  // Get stream IDs
+  DWORD input_count = 0, output_count = 0;
+  hr = decoder_->GetStreamCount(&input_count, &output_count);
+  if (SUCCEEDED(hr) && input_count > 0 && output_count > 0) {
+    std::vector<DWORD> input_ids(input_count), output_ids(output_count);
+    hr = decoder_->GetStreamIDs(input_count, input_ids.data(), output_count,
+                                output_ids.data());
+    if (SUCCEEDED(hr)) {
+      input_stream_id_ = input_ids[0];
+      output_stream_id_ = output_ids[0];
+    } else {
+      input_stream_id_ = 0;
+      output_stream_id_ = 0;
+    }
+  }
+
+  hr = ConfigureInputType();
+  if (FAILED(hr)) return false;
+
+  hr = ConfigureOutputType();
+  if (FAILED(hr)) return false;
+
+  hr = decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0);
+  hr = decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0);
+  hr = decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
+
+  initialized_ = true;
+  RTC_LOG(LS_INFO) << "WMF H.265 decoder initialized.";
+  return true;
+}
+
+HRESULT WmfH265Decoder::ProcessInput(const uint8_t* data, size_t size,
+                                      int64_t timestamp_us) {
+  Microsoft::WRL::ComPtr<IMFSample> sample;
+  HRESULT hr = MFCreateSample(&sample);
+  if (FAILED(hr)) return hr;
+
+  Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer;
+  hr = MFCreateMemoryBuffer(static_cast<DWORD>(size), &buffer);
+  if (FAILED(hr)) return hr;
+
+  BYTE* buffer_data = nullptr;
+  hr = buffer->Lock(&buffer_data, nullptr, nullptr);
+  if (FAILED(hr)) return hr;
+
+  memcpy(buffer_data, data, size);
+
+  hr = buffer->Unlock();
+  if (FAILED(hr)) return hr;
+
+  hr = buffer->SetCurrentLength(static_cast<DWORD>(size));
+  if (FAILED(hr)) return hr;
+
+  hr = sample->AddBuffer(buffer.Get());
+  if (FAILED(hr)) return hr;
+
+  // Set sample time in 100ns units
+  LONGLONG sample_time = timestamp_us * 10;
+  sample->SetSampleTime(sample_time);
+
+  hr = decoder_->ProcessInput(input_stream_id_, sample.Get(), 0);
+  return hr;
+}
+
+HRESULT WmfH265Decoder::ProcessOutput(int64_t timestamp_us,
+                                       int64_t ntp_time_ms,
+                                       uint32_t rtp_timestamp) {
+  MFT_OUTPUT_DATA_BUFFER output_data = {};
+  output_data.dwStreamID = output_stream_id_;
+
+  MFT_OUTPUT_STREAM_INFO stream_info = {};
+  HRESULT hr = decoder_->GetOutputStreamInfo(output_stream_id_, &stream_info);
+  if (FAILED(hr)) return hr;
+
+  bool provides_samples =
+      (stream_info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES);
+
+  Microsoft::WRL::ComPtr<IMFSample> output_sample;
+  if (!provides_samples) {
+    hr = MFCreateSample(&output_sample);
+    if (FAILED(hr)) return hr;
+
+    Microsoft::WRL::ComPtr<IMFMediaBuffer> output_buffer;
+    DWORD buffer_size = std::max(stream_info.cbSize,
+        static_cast<DWORD>((width_ > 0 ? width_ : 1920) *
+                           (height_ > 0 ? height_ : 1080) * 3));
+    hr = MFCreateMemoryBuffer(buffer_size, &output_buffer);
+    if (FAILED(hr)) return hr;
+
+    hr = output_sample->AddBuffer(output_buffer.Get());
+    if (FAILED(hr)) return hr;
+
+    output_data.pSample = output_sample.Get();
+  }
+
+  DWORD status = 0;
+  hr = decoder_->ProcessOutput(0, 1, &output_data, &status);
+
+  if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+    return hr;
+  }
+
+  if (hr == MF_E_TRANSFORM_STREAM_CHANGE) {
+    // Output format changed, reconfigure
+    ConfigureOutputType();
+    // Update cached dimensions from new output type
+    if (output_type_) {
+      UINT32 new_w = 0, new_h = 0;
+      MFGetAttributeSize(output_type_.Get(), MF_MT_FRAME_SIZE, &new_w, &new_h);
+      if (new_w > 0 && new_h > 0) {
+        width_ = static_cast<int32_t>(new_w);
+        height_ = static_cast<int32_t>(new_h);
+      }
+    }
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  if (FAILED(hr)) {
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  IMFSample* result_sample =
+      provides_samples ? output_data.pSample : output_sample.Get();
+  if (!result_sample) {
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return E_FAIL;
+  }
+
+  // Get actual frame dimensions from output type
+  UINT32 out_width = 0, out_height = 0;
+  if (output_type_) {
+    MFGetAttributeSize(output_type_.Get(), MF_MT_FRAME_SIZE, &out_width,
+                       &out_height);
+  }
+  if (out_width == 0 || out_height == 0) {
+    out_width = width_ > 0 ? width_ : 1920;
+    out_height = height_ > 0 ? height_ : 1080;
+  }
+
+  // Extract decoded frame
+  Microsoft::WRL::ComPtr<IMFMediaBuffer> result_buffer;
+  hr = result_sample->ConvertToContiguousBuffer(&result_buffer);
+  if (FAILED(hr)) {
+    if (provides_samples && output_data.pSample)
+      output_data.pSample->Release();
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  BYTE* data = nullptr;
+  DWORD data_length = 0;
+  hr = result_buffer->Lock(&data, nullptr, &data_length);
+  if (FAILED(hr)) {
+    if (provides_samples && output_data.pSample)
+      output_data.pSample->Release();
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  // Get stride info
+  LONG stride = out_width;
+  if (output_type_) {
+    UINT32 default_stride = 0;
+    HRESULT stride_hr =
+        output_type_->GetUINT32(MF_MT_DEFAULT_STRIDE, &default_stride);
+    if (SUCCEEDED(stride_hr)) {
+      stride = static_cast<LONG>(default_stride);
+    }
+  }
+
+  // Check output subtype
+  GUID out_subtype = MFVideoFormat_NV12;
+  if (output_type_) {
+    output_type_->GetGUID(MF_MT_SUBTYPE, &out_subtype);
+  }
+
+  // Convert to I420
+  rtc::scoped_refptr<I420Buffer> i420_buffer =
+      I420Buffer::Create(out_width, out_height);
+
+  if (out_subtype == MFVideoFormat_NV12) {
+    libyuv::NV12ToI420(data, stride,
+                       data + stride * out_height, stride,
+                       i420_buffer->MutableDataY(), i420_buffer->StrideY(),
+                       i420_buffer->MutableDataU(), i420_buffer->StrideU(),
+                       i420_buffer->MutableDataV(), i420_buffer->StrideV(),
+                       out_width, out_height);
+  } else {
+    // Assume I420/IYUV
+    int y_size = stride * out_height;
+    int uv_stride = (stride + 1) / 2;
+    int uv_size = uv_stride * ((out_height + 1) / 2);
+    libyuv::I420Copy(data, stride, data + y_size, uv_stride,
+                     data + y_size + uv_size, uv_stride,
+                     i420_buffer->MutableDataY(), i420_buffer->StrideY(),
+                     i420_buffer->MutableDataU(), i420_buffer->StrideU(),
+                     i420_buffer->MutableDataV(), i420_buffer->StrideV(),
+                     out_width, out_height);
+  }
+
+  result_buffer->Unlock();
+
+  if (provides_samples && output_data.pSample) {
+    output_data.pSample->Release();
+  }
+  if (output_data.pEvents) {
+    output_data.pEvents->Release();
+  }
+
+  // Deliver decoded frame
+  if (callback_) {
+    VideoFrame decoded_frame =
+        VideoFrame::Builder()
+            .set_video_frame_buffer(i420_buffer)
+            .set_timestamp_rtp(rtp_timestamp)
+            .set_ntp_time_ms(ntp_time_ms)
+            .set_timestamp_us(timestamp_us)
+            .build();
+
+    callback_->Decoded(decoded_frame);
+  }
+
+  return S_OK;
+}
+
+int32_t WmfH265Decoder::Decode(const EncodedImage& input_image,
+                                bool missing_frames,
+                                int64_t render_time_ms) {
+  if (!initialized_ || !callback_) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  if (input_image.data() == nullptr || input_image.size() == 0) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  int64_t timestamp_us =
+      static_cast<int64_t>(input_image.RtpTimestamp()) * 1000 / 90;
+
+  HRESULT hr = ProcessInput(input_image.data(), input_image.size(),
+                            timestamp_us);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Decode ProcessInput failed: " << static_cast<int>(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Drain all available output
+  while (true) {
+    hr = ProcessOutput(timestamp_us, input_image.ntp_time_ms_,
+                       input_image.RtpTimestamp());
+    if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+      break;
+    }
+    if (hr == MF_E_TRANSFORM_STREAM_CHANGE) {
+      continue;  // Retry with new output type
+    }
+    if (FAILED(hr)) {
+      break;
+    }
+  }
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t WmfH265Decoder::RegisterDecodeCompleteCallback(
+    DecodedImageCallback* callback) {
+  callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t WmfH265Decoder::Release() {
+  if (decoder_) {
+    decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+    decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0);
+    decoder_.Reset();
+  }
+
+  input_type_.Reset();
+  output_type_.Reset();
+
+  if (mf_started_) {
+    MFShutdown();
+    mf_started_ = false;
+  }
+
+  if (com_initialized_) {
+    CoUninitialize();
+    com_initialized_ = false;
+  }
+
+  initialized_ = false;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+const char* WmfH265Decoder::ImplementationName() const {
+  return "WMF_H265";
+}
+
+VideoDecoder::DecoderInfo WmfH265Decoder::GetDecoderInfo() const {
+  DecoderInfo info;
+  info.implementation_name = "WMF_H265";
+  info.is_hardware_accelerated = true;
+  return info;
+}
+
+}  // namespace webrtc

--- a/src/win/wmf_h265_decoder.h
+++ b/src/win/wmf_h265_decoder.h
@@ -1,0 +1,67 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LIB_WEBRTC_WIN_WMF_H265_DECODER_H_
+#define LIB_WEBRTC_WIN_WMF_H265_DECODER_H_
+
+#include <d3d11.h>
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+#include <wrl/client.h>
+
+#include <memory>
+#include <vector>
+
+#include "api/video/i420_buffer.h"
+#include "api/video/video_frame.h"
+#include "api/video_codecs/video_codec.h"
+#include "api/video_codecs/video_decoder.h"
+
+namespace webrtc {
+
+class WmfH265Decoder : public VideoDecoder {
+ public:
+  WmfH265Decoder();
+  ~WmfH265Decoder() override;
+
+  static std::unique_ptr<WmfH265Decoder> Create();
+  static bool IsSupported();
+
+  bool Configure(const Settings& settings) override;
+  int32_t Decode(const EncodedImage& input_image, bool missing_frames,
+                 int64_t render_time_ms) override;
+  int32_t RegisterDecodeCompleteCallback(
+      DecodedImageCallback* callback) override;
+  int32_t Release() override;
+  DecoderInfo GetDecoderInfo() const override;
+  const char* ImplementationName() const override;
+
+ private:
+  HRESULT InitMediaFoundation();
+  HRESULT CreateHEVCDecoder();
+  HRESULT ConfigureInputType();
+  HRESULT ConfigureOutputType();
+  HRESULT ProcessInput(const uint8_t* data, size_t size, int64_t timestamp_us);
+  HRESULT ProcessOutput(int64_t timestamp_us, int64_t ntp_time_ms,
+                        uint32_t rtp_timestamp);
+
+  DecodedImageCallback* callback_ = nullptr;
+  bool initialized_ = false;
+  bool mf_started_ = false;
+  bool com_initialized_ = false;
+  int32_t width_ = 0;
+  int32_t height_ = 0;
+
+  Microsoft::WRL::ComPtr<IMFTransform> decoder_;
+  Microsoft::WRL::ComPtr<IMFMediaType> input_type_;
+  Microsoft::WRL::ComPtr<IMFMediaType> output_type_;
+
+  DWORD input_stream_id_ = 0;
+  DWORD output_stream_id_ = 0;
+};
+
+}  // namespace webrtc
+
+#endif  // LIB_WEBRTC_WIN_WMF_H265_DECODER_H_

--- a/src/win/wmf_h265_encoder.cc
+++ b/src/win/wmf_h265_encoder.cc
@@ -1,0 +1,637 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "src/win/wmf_h265_encoder.h"
+
+#include <codecapi.h>
+#include <mftransform.h>
+#include <wmcodecdsp.h>
+
+#include <algorithm>
+
+#include "api/video/encoded_image.h"
+#include "api/video/i420_buffer.h"
+#include "api/video/video_codec_type.h"
+#include "common_video/libyuv/include/webrtc_libyuv.h"
+#include "media/base/media_constants.h"
+#include "modules/video_coding/include/video_codec_interface.h"
+#include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/string_utils.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "mfuuid.lib")
+#pragma comment(lib, "mf.lib")
+
+namespace webrtc {
+
+WmfH265Encoder::WmfH265Encoder(const VideoCodec& codec)
+    : codec_settings_(codec) {}
+
+WmfH265Encoder::~WmfH265Encoder() {
+  Release();
+}
+
+std::unique_ptr<WmfH265Encoder> WmfH265Encoder::Create(
+    const VideoCodec& codec) {
+  if (!IsSupported()) {
+    RTC_LOG(LS_ERROR) << "WMF H.265 encoder is not supported on this system.";
+    return nullptr;
+  }
+  return std::make_unique<WmfH265Encoder>(codec);
+}
+
+bool WmfH265Encoder::IsSupported() {
+  // Ensure COM is initialized on this thread (MF requires it)
+  HRESULT com_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  bool should_uninit_com = SUCCEEDED(com_hr);
+
+  // Check if we can activate a HEVC encoder MFT
+  HRESULT hr = MFStartup(MF_VERSION);
+  if (FAILED(hr)) {
+    if (should_uninit_com) CoUninitialize();
+    return false;
+  }
+
+  // Enumerate HEVC encoders
+  MFT_REGISTER_TYPE_INFO output_type = {MFMediaType_Video,
+                                        MFVideoFormat_HEVC};
+  IMFActivate** activate = nullptr;
+  UINT32 count = 0;
+
+  hr = MFTEnumEx(MFT_CATEGORY_VIDEO_ENCODER,
+                 MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_ASYNCMFT |
+                     MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+                 nullptr, &output_type, &activate, &count);
+
+  bool supported = SUCCEEDED(hr) && count > 0;
+
+  // Clean up
+  if (activate) {
+    for (UINT32 i = 0; i < count; i++) {
+      activate[i]->Release();
+    }
+    CoTaskMemFree(activate);
+  }
+
+  MFShutdown();
+  if (should_uninit_com) CoUninitialize();
+  return supported;
+}
+
+HRESULT WmfH265Encoder::InitMediaFoundation() {
+  // Ensure COM is initialized on the calling thread
+  HRESULT com_hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  if (SUCCEEDED(com_hr)) {
+    com_initialized_ = true;
+  } else if (com_hr != RPC_E_CHANGED_MODE) {
+    RTC_LOG(LS_ERROR) << "CoInitializeEx failed: " << static_cast<int>(com_hr);
+    return com_hr;
+  }
+
+  HRESULT hr = MFStartup(MF_VERSION);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFStartup failed: " << static_cast<int>(hr);
+    if (com_initialized_) {
+      CoUninitialize();
+      com_initialized_ = false;
+    }
+    return hr;
+  }
+  mf_started_ = true;
+  return S_OK;
+}
+
+HRESULT WmfH265Encoder::CreateHEVCEncoder() {
+  // Enumerate and activate HEVC encoders (prefer hardware)
+  MFT_REGISTER_TYPE_INFO output_type = {MFMediaType_Video,
+                                        MFVideoFormat_HEVC};
+  IMFActivate** activate = nullptr;
+  UINT32 count = 0;
+
+  HRESULT hr = MFTEnumEx(
+      MFT_CATEGORY_VIDEO_ENCODER,
+      MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_ASYNCMFT |
+          MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+      nullptr, &output_type, &activate, &count);
+
+  if (FAILED(hr) || count == 0) {
+    RTC_LOG(LS_ERROR) << "No HEVC encoder MFT found. hr=" << static_cast<int>(hr);
+    if (activate) CoTaskMemFree(activate);
+    return E_FAIL;
+  }
+
+  // Log available encoders
+  for (UINT32 i = 0; i < count; i++) {
+    LPWSTR friendly_name = nullptr;
+    UINT32 name_len = 0;
+    activate[i]->GetAllocatedString(MFT_FRIENDLY_NAME_Attribute,
+                                    &friendly_name, &name_len);
+    if (friendly_name) {
+      RTC_LOG(LS_INFO) << "Found HEVC encoder: "
+                       << webrtc::ToUtf8(friendly_name, name_len);
+      CoTaskMemFree(friendly_name);
+    }
+  }
+
+  // Activate the first (highest priority) encoder
+  hr = activate[0]->ActivateObject(IID_PPV_ARGS(&encoder_));
+
+  for (UINT32 i = 0; i < count; i++) {
+    activate[i]->Release();
+  }
+  CoTaskMemFree(activate);
+
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to activate HEVC encoder MFT: " << static_cast<int>(hr);
+    return hr;
+  }
+  // Set low-latency mode for real-time encoding
+  Microsoft::WRL::ComPtr<IMFAttributes> attributes;
+  hr = encoder_->GetAttributes(&attributes);
+  if (SUCCEEDED(hr)) {
+    attributes->SetUINT32(MF_LOW_LATENCY, TRUE);
+  }
+
+  RTC_LOG(LS_INFO) << "HEVC encoder MFT activated successfully.";
+  return S_OK;
+}
+
+HRESULT WmfH265Encoder::ConfigureRateControl() {
+  Microsoft::WRL::ComPtr<ICodecAPI> codec_api;
+  HRESULT hr = encoder_.As(&codec_api);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING) << "ICodecAPI not available, skipping rate control setup.";
+    return S_OK;  // Non-fatal: MFT will use its default
+  }
+
+  // Set CBR mode — required for WebRTC real-time streaming
+  VARIANT var;
+  VariantInit(&var);
+  var.vt = VT_UI4;
+  var.ulVal = eAVEncCommonRateControlMode_CBR;
+  hr = codec_api->SetValue(&CODECAPI_AVEncCommonRateControlMode, &var);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING) << "Failed to set CBR rate control: "
+                        << static_cast<int>(hr);
+  }
+
+  return S_OK;
+}
+
+HRESULT WmfH265Encoder::ConfigureOutputType() {
+  HRESULT hr = MFCreateMediaType(&output_type_);
+  if (FAILED(hr)) return hr;
+
+  output_type_->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+  output_type_->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_HEVC);
+  MFSetAttributeSize(output_type_.Get(), MF_MT_FRAME_SIZE, width_, height_);
+  MFSetAttributeRatio(output_type_.Get(), MF_MT_FRAME_RATE, frame_rate_, 1);
+  output_type_->SetUINT32(MF_MT_AVG_BITRATE, target_bitrate_bps_);
+  output_type_->SetUINT32(MF_MT_INTERLACE_MODE,
+                          MFVideoInterlace_Progressive);
+  MFSetAttributeRatio(output_type_.Get(), MF_MT_PIXEL_ASPECT_RATIO, 1, 1);
+
+  // Set HEVC profile to Main
+  output_type_->SetUINT32(MF_MT_MPEG2_PROFILE, 1);  // Main profile
+  output_type_->SetUINT32(MF_MT_MPEG2_LEVEL, 120);   // Level 4.0
+
+  hr = encoder_->SetOutputType(output_stream_id_, output_type_.Get(), 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetOutputType failed: " << static_cast<int>(hr);
+    return hr;
+  }
+
+  return S_OK;
+}
+
+HRESULT WmfH265Encoder::ConfigureInputType() {
+  HRESULT hr = MFCreateMediaType(&input_type_);
+  if (FAILED(hr)) return hr;
+
+  input_type_->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+  input_type_->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_NV12);
+  MFSetAttributeSize(input_type_.Get(), MF_MT_FRAME_SIZE, width_, height_);
+  MFSetAttributeRatio(input_type_.Get(), MF_MT_FRAME_RATE, frame_rate_, 1);
+  input_type_->SetUINT32(MF_MT_INTERLACE_MODE,
+                         MFVideoInterlace_Progressive);
+  MFSetAttributeRatio(input_type_.Get(), MF_MT_PIXEL_ASPECT_RATIO, 1, 1);
+
+  hr = encoder_->SetInputType(input_stream_id_, input_type_.Get(), 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetInputType failed: " << static_cast<int>(hr);
+    return hr;
+  }
+
+  return S_OK;
+}
+
+int WmfH265Encoder::InitEncode(const VideoCodec* codec_settings,
+                                const Settings& settings) {
+  if (!codec_settings) {
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  Release();
+
+  codec_settings_ = *codec_settings;
+  width_ = codec_settings->width;
+  height_ = codec_settings->height;
+  target_bitrate_bps_ = codec_settings->startBitrate * 1000;
+  max_bitrate_bps_ = codec_settings->maxBitrate * 1000;
+  frame_rate_ = codec_settings->maxFramerate;
+  if (frame_rate_ == 0) frame_rate_ = 30;
+
+  HRESULT hr = InitMediaFoundation();
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  hr = CreateHEVCEncoder();
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Get stream IDs
+  DWORD input_count = 0, output_count = 0;
+  hr = encoder_->GetStreamCount(&input_count, &output_count);
+  if (SUCCEEDED(hr) && input_count > 0 && output_count > 0) {
+    // Try getting explicit IDs
+    std::vector<DWORD> input_ids(input_count), output_ids(output_count);
+    hr = encoder_->GetStreamIDs(input_count, input_ids.data(), output_count,
+                                output_ids.data());
+    if (SUCCEEDED(hr)) {
+      input_stream_id_ = input_ids[0];
+      output_stream_id_ = output_ids[0];
+    } else {
+      // If E_NOTIMPL, stream IDs are sequential starting from 0
+      input_stream_id_ = 0;
+      output_stream_id_ = 0;
+    }
+  }
+
+  // Must set output type before input type for most MF encoders
+  hr = ConfigureOutputType();
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  hr = ConfigureInputType();
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Set rate control after media types are configured
+  hr = ConfigureRateControl();
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Pre-allocate NV12 conversion buffer
+  nv12_buffer_.resize(width_ * height_ * 3 / 2);
+
+  // Start processing
+  hr = encoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0);
+  hr = encoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0);
+  hr = encoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to start encoder streaming: " << static_cast<int>(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  initialized_ = true;
+  RTC_LOG(LS_INFO) << "WMF H.265 encoder initialized: " << width_ << "x"
+                   << height_ << " @ " << frame_rate_ << "fps, "
+                   << target_bitrate_bps_ / 1000 << " kbps";
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+HRESULT WmfH265Encoder::ProcessInput(const VideoFrame& frame) {
+  rtc::scoped_refptr<I420BufferInterface> i420_buffer =
+      frame.video_frame_buffer()->ToI420();
+
+  int y_stride = i420_buffer->StrideY();
+  int u_stride = i420_buffer->StrideU();
+  int v_stride = i420_buffer->StrideV();
+
+  // Create NV12 buffer
+  int nv12_size = width_ * height_ * 3 / 2;
+
+  // Convert I420 to NV12 using pre-allocated buffer
+  libyuv::I420ToNV12(
+      i420_buffer->DataY(), y_stride, i420_buffer->DataU(), u_stride,
+      i420_buffer->DataV(), v_stride, nv12_buffer_.data(), width_,
+      nv12_buffer_.data() + width_ * height_, width_, width_, height_);
+
+  // Create MF sample
+  Microsoft::WRL::ComPtr<IMFSample> sample;
+  HRESULT hr = MFCreateSample(&sample);
+  if (FAILED(hr)) return hr;
+
+  Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer;
+  hr = MFCreateMemoryBuffer(nv12_size, &buffer);
+  if (FAILED(hr)) return hr;
+
+  BYTE* buffer_data = nullptr;
+  hr = buffer->Lock(&buffer_data, nullptr, nullptr);
+  if (FAILED(hr)) return hr;
+
+  memcpy(buffer_data, nv12_buffer_.data(), nv12_size);
+
+  hr = buffer->Unlock();
+  if (FAILED(hr)) return hr;
+
+  hr = buffer->SetCurrentLength(nv12_size);
+  if (FAILED(hr)) return hr;
+
+  hr = sample->AddBuffer(buffer.Get());
+  if (FAILED(hr)) return hr;
+
+  // Set sample time (100-nanosecond units)
+  LONGLONG sample_time = frame.timestamp_us() * 10;
+  sample->SetSampleTime(sample_time);
+  sample->SetSampleDuration(static_cast<LONGLONG>(10000000.0 / frame_rate_));
+
+  hr = encoder_->ProcessInput(input_stream_id_, sample.Get(), 0);
+  return hr;
+}
+
+int32_t WmfH265Encoder::NextNaluPosition(uint8_t* buffer,
+                                          size_t buffer_size,
+                                          uint8_t* sc_length) {
+  if (buffer_size < 3) return -1;
+
+  *sc_length = 0;
+  for (size_t i = 0; i < buffer_size - 3; i++) {
+    if (buffer[i] == 0 && buffer[i + 1] == 0) {
+      if (buffer[i + 2] == 1) {
+        *sc_length = 3;
+        return static_cast<int32_t>(i);
+      }
+      if (i < buffer_size - 4 && buffer[i + 2] == 0 && buffer[i + 3] == 1) {
+        *sc_length = 4;
+        return static_cast<int32_t>(i);
+      }
+    }
+  }
+  return -1;
+}
+
+HRESULT WmfH265Encoder::ProcessOutput(int64_t timestamp_us,
+                                       int64_t ntp_time_ms,
+                                       uint32_t rtp_timestamp) {
+  MFT_OUTPUT_DATA_BUFFER output_data = {};
+  output_data.dwStreamID = output_stream_id_;
+
+  // Check if we need to provide the output sample
+  MFT_OUTPUT_STREAM_INFO stream_info = {};
+  HRESULT hr = encoder_->GetOutputStreamInfo(output_stream_id_, &stream_info);
+  if (FAILED(hr)) return hr;
+
+  bool provides_samples =
+      (stream_info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES);
+
+  Microsoft::WRL::ComPtr<IMFSample> output_sample;
+  if (!provides_samples) {
+    hr = MFCreateSample(&output_sample);
+    if (FAILED(hr)) return hr;
+
+    Microsoft::WRL::ComPtr<IMFMediaBuffer> output_buffer;
+    DWORD buffer_size =
+        std::max(stream_info.cbSize, static_cast<DWORD>(width_ * height_ * 2));
+    hr = MFCreateMemoryBuffer(buffer_size, &output_buffer);
+    if (FAILED(hr)) return hr;
+
+    hr = output_sample->AddBuffer(output_buffer.Get());
+    if (FAILED(hr)) return hr;
+
+    output_data.pSample = output_sample.Get();
+  }
+
+  DWORD status = 0;
+  hr = encoder_->ProcessOutput(0, 1, &output_data, &status);
+
+  if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+    return hr;  // Not an error, just need more input
+  }
+
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "ProcessOutput failed: " << static_cast<int>(hr);
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  IMFSample* result_sample =
+      provides_samples ? output_data.pSample : output_sample.Get();
+  if (!result_sample) {
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return E_FAIL;
+  }
+
+  // Extract encoded data
+  Microsoft::WRL::ComPtr<IMFMediaBuffer> result_buffer;
+  hr = result_sample->ConvertToContiguousBuffer(&result_buffer);
+  if (FAILED(hr)) {
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  BYTE* data = nullptr;
+  DWORD data_length = 0;
+  hr = result_buffer->Lock(&data, nullptr, &data_length);
+  if (FAILED(hr)) {
+    if (output_data.pEvents) output_data.pEvents->Release();
+    return hr;
+  }
+
+  if (data_length > 0 && callback_) {
+    // Determine frame type by scanning NALUs
+    bool is_keyframe = false;
+    uint8_t sc_length = 0;
+    size_t offset = 0;
+
+    while (offset < data_length) {
+      int nalu_pos =
+          NextNaluPosition(data + offset, data_length - offset, &sc_length);
+      if (nalu_pos < 0) break;
+
+      size_t nalu_start = offset + nalu_pos + sc_length;
+      if (nalu_start < data_length) {
+        // H.265 NALU type is in bits 1-6 of the first byte
+        uint8_t nalu_type = (data[nalu_start] >> 1) & 0x3F;
+        // IRAP VCL NALUs only: BLA_W_LP(16) through RSV_IRAP_VCL23(23)
+        // VPS(32)/SPS(33)/PPS(34) are non-VCL and should NOT mark keyframe
+        if (nalu_type >= 16 && nalu_type <= 23) {
+          is_keyframe = true;
+        }
+      }
+      offset = nalu_start + 1;
+    }
+
+    // Create encoded image
+    EncodedImage encoded_image;
+    encoded_image.SetEncodedData(
+        EncodedImageBuffer::Create(data, data_length));
+    encoded_image._encodedWidth = width_;
+    encoded_image._encodedHeight = height_;
+    // Preserve the RTP timestamp from the upstream WebRTC frame
+    // to avoid drift between encoder and RTP sender.
+    encoded_image.SetRtpTimestamp(rtp_timestamp);
+    encoded_image.capture_time_ms_ = timestamp_us / 1000;
+    encoded_image.ntp_time_ms_ = ntp_time_ms;
+    encoded_image._frameType =
+        is_keyframe ? VideoFrameType::kVideoFrameKey
+                    : VideoFrameType::kVideoFrameDelta;
+    encoded_image.SetSpatialIndex(0);
+
+    // Parse bitstream for QP
+    bitstream_parser_.ParseBitstream(
+        rtc::ArrayView<const uint8_t>(data, data_length));
+    
+    std::optional<int> qp = bitstream_parser_.GetLastSliceQp();
+    if (qp.has_value()) {
+      encoded_image.qp_ = *qp;
+    } 
+    CodecSpecificInfo codec_info;
+    codec_info.codecType = kVideoCodecH265;
+
+    callback_->OnEncodedImage(encoded_image, &codec_info);
+  }
+
+  result_buffer->Unlock();
+
+  if (provides_samples && output_data.pSample) {
+    output_data.pSample->Release();
+  }
+  if (output_data.pEvents) {
+    output_data.pEvents->Release();
+  }
+
+  return S_OK;
+}
+
+int WmfH265Encoder::Encode(const VideoFrame& input_image,
+                            const std::vector<VideoFrameType>* frame_types) {
+  if (!initialized_ || !callback_) {
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  // Check for keyframe request
+  bool force_key_frame = false;
+  if (frame_types) {
+    for (const auto& frame_type : *frame_types) {
+      if (frame_type == VideoFrameType::kVideoFrameKey) {
+        force_key_frame = true;
+        break;
+      }
+    }
+  }
+
+  if (force_key_frame) {
+    // Request IDR from MFT via CODECAPI
+    Microsoft::WRL::ComPtr<ICodecAPI> codec_api;
+    HRESULT hr = encoder_.As(&codec_api);
+    if (SUCCEEDED(hr)) {
+      VARIANT var;
+      VariantInit(&var);
+      var.vt = VT_UI4;
+      var.ulVal = 1;
+      codec_api->SetValue(&CODECAPI_AVEncVideoForceKeyFrame, &var);
+    }
+  }
+
+  // Process input
+  HRESULT hr = ProcessInput(input_image);
+  if (hr == MF_E_NOTACCEPTING) {
+    // MFT input buffer full — drain output first, then retry
+    while (true) {
+      HRESULT out_hr = ProcessOutput(input_image.timestamp_us(),
+                                     input_image.ntp_time_ms(),
+                                     input_image.rtp_timestamp());
+      if (out_hr == MF_E_TRANSFORM_NEED_MORE_INPUT || FAILED(out_hr)) break;
+    }
+    hr = ProcessInput(input_image);
+  }
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "ProcessInput failed: " << static_cast<int>(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Try to get output
+  while (true) {
+    hr = ProcessOutput(input_image.timestamp_us(), input_image.ntp_time_ms(),
+                        input_image.rtp_timestamp());
+    if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+      break;  // Need more input before getting output
+    }
+    if (FAILED(hr)) {
+      break;
+    }
+  }
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int WmfH265Encoder::RegisterEncodeCompleteCallback(
+    EncodedImageCallback* callback) {
+  callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+void WmfH265Encoder::SetRates(const RateControlParameters& parameters) {
+  if (!initialized_ || !encoder_) return;
+
+  target_bitrate_bps_ = parameters.bitrate.get_sum_bps();
+  frame_rate_ = static_cast<uint32_t>(parameters.framerate_fps);
+  if (frame_rate_ == 0) frame_rate_ = 30;
+
+  // Update bitrate via CODECAPI
+  Microsoft::WRL::ComPtr<ICodecAPI> codec_api;
+  HRESULT hr = encoder_.As(&codec_api);
+  if (SUCCEEDED(hr)) {
+    VARIANT var;
+    VariantInit(&var);
+    var.vt = VT_UI4;
+    var.ulVal = target_bitrate_bps_;
+    codec_api->SetValue(&CODECAPI_AVEncCommonMeanBitRate, &var);
+  }
+}
+
+VideoEncoder::EncoderInfo WmfH265Encoder::GetEncoderInfo() const {
+  EncoderInfo info;
+  info.implementation_name = "WMF_H265";
+  info.is_hardware_accelerated = true;
+  info.supports_native_handle = false;
+  info.supports_simulcast = false;
+  info.requested_resolution_alignment = 2;  // NV12 requires even dimensions
+  return info;
+}
+
+int WmfH265Encoder::Release() {
+  if (encoder_) {
+    encoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+    encoder_->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0);
+    encoder_.Reset();
+  }
+
+  input_type_.Reset();
+  output_type_.Reset();
+
+  if (mf_started_) {
+    MFShutdown();
+    mf_started_ = false;
+  }
+
+  if (com_initialized_) {
+    CoUninitialize();
+    com_initialized_ = false;
+  }
+
+  initialized_ = false;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+}  // namespace webrtc

--- a/src/win/wmf_h265_encoder.h
+++ b/src/win/wmf_h265_encoder.h
@@ -1,0 +1,78 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LIB_WEBRTC_WIN_WMF_H265_ENCODER_H_
+#define LIB_WEBRTC_WIN_WMF_H265_ENCODER_H_
+
+#include <d3d11.h>
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+#include <wrl/client.h>
+
+#include <memory>
+#include <vector>
+
+#include "api/video/video_frame.h"
+#include "api/video_codecs/video_codec.h"
+#include "api/video_codecs/video_encoder.h"
+#include "common_video/h265/h265_bitstream_parser.h"
+#include "rtc_base/synchronization/mutex.h"
+
+namespace webrtc {
+
+class WmfH265Encoder : public VideoEncoder {
+ public:
+  explicit WmfH265Encoder(const VideoCodec& codec);
+  ~WmfH265Encoder() override;
+
+  static std::unique_ptr<WmfH265Encoder> Create(const VideoCodec& codec);
+  static bool IsSupported();
+
+  int InitEncode(const VideoCodec* codec_settings,
+                 const Settings& settings) override;
+  int Encode(const VideoFrame& input_image,
+             const std::vector<VideoFrameType>* frame_types) override;
+  int RegisterEncodeCompleteCallback(EncodedImageCallback* callback) override;
+  void SetRates(const RateControlParameters& parameters) override;
+  EncoderInfo GetEncoderInfo() const override;
+  int Release() override;
+
+ private:
+  HRESULT InitMediaFoundation();
+  HRESULT CreateHEVCEncoder();
+  HRESULT ConfigureInputType();
+  HRESULT ConfigureOutputType();
+  HRESULT ConfigureRateControl();
+  HRESULT ProcessInput(const VideoFrame& frame);
+  HRESULT ProcessOutput(int64_t timestamp_us, int64_t ntp_time_ms,
+                        uint32_t rtp_timestamp);
+  int32_t NextNaluPosition(uint8_t* buffer, size_t buffer_size,
+                           uint8_t* sc_length);
+
+  EncodedImageCallback* callback_ = nullptr;
+  VideoCodec codec_settings_;
+  int32_t width_ = 0;
+  int32_t height_ = 0;
+  uint32_t target_bitrate_bps_ = 0;
+  uint32_t max_bitrate_bps_ = 0;
+  uint32_t frame_rate_ = 30;
+  bool initialized_ = false;
+  bool mf_started_ = false;
+  bool com_initialized_ = false;
+
+  Microsoft::WRL::ComPtr<IMFTransform> encoder_;
+  Microsoft::WRL::ComPtr<IMFMediaType> input_type_;
+  Microsoft::WRL::ComPtr<IMFMediaType> output_type_;
+
+  DWORD input_stream_id_ = 0;
+  DWORD output_stream_id_ = 0;
+
+  std::vector<uint8_t> nv12_buffer_;
+  H265BitstreamParser bitstream_parser_;
+};
+
+}  // namespace webrtc
+
+#endif  // LIB_WEBRTC_WIN_WMF_H265_ENCODER_H_

--- a/src/win/wmf_h265_factory.cc
+++ b/src/win/wmf_h265_factory.cc
@@ -1,0 +1,150 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "src/win/wmf_h265_factory.h"
+
+#include "api/environment/environment.h"
+#include "api/video_codecs/sdp_video_format.h"
+#include "media/base/media_constants.h"
+#include "media/engine/simulcast_encoder_adapter.h"
+#include "rtc_base/logging.h"
+#include "src/win/wmf_h265_decoder.h"
+#include "src/win/wmf_h265_encoder.h"
+
+namespace webrtc {
+
+namespace {
+
+// H.265 SDP formats to advertise
+std::vector<SdpVideoFormat> GetSupportedH265Formats() {
+  return {SdpVideoFormat(kH265CodecName,
+                         {{"profile-id", "1"},    // Main profile
+                          {"tier-flag", "0"},      // Main tier
+                          {"level-id", "120"}})};  // Level 4.0
+}
+
+// ------- Encoder factory -------
+
+class WmfH265VideoEncoderFactory : public VideoEncoderFactory {
+ public:
+  explicit WmfH265VideoEncoderFactory(
+      std::unique_ptr<VideoEncoderFactory> builtin)
+      : builtin_(std::move(builtin)),
+        h265_supported_(WmfH265Encoder::IsSupported()) {
+    if (h265_supported_) {
+      RTC_LOG(LS_INFO) << "WMF H.265 encoder is available.";
+    } else {
+      RTC_LOG(LS_WARNING) << "WMF H.265 encoder is NOT available.";
+    }
+  }
+
+  std::unique_ptr<VideoEncoder> Create(const Environment& env,
+                                       const SdpVideoFormat& format) override {
+    if (h265_supported_ &&
+        absl::EqualsIgnoreCase(format.name, kH265CodecName)) {
+      VideoCodec codec;
+      codec.codecType = kVideoCodecH265;
+      auto encoder = WmfH265Encoder::Create(codec);
+      if (encoder) {
+        return encoder;
+      }
+      RTC_LOG(LS_WARNING)
+          << "Failed to create WMF H.265 encoder, no fallback available.";
+      return nullptr;
+    }
+    return builtin_->Create(env, format);
+  }
+
+  std::vector<SdpVideoFormat> GetSupportedFormats() const override {
+    auto formats = builtin_->GetSupportedFormats();
+    if (h265_supported_) {
+      auto h265_formats = GetSupportedH265Formats();
+      formats.insert(formats.end(), h265_formats.begin(),
+                     h265_formats.end());
+    }
+    return formats;
+  }
+
+  CodecSupport QueryCodecSupport(
+      const SdpVideoFormat& format,
+      std::optional<std::string> scalability_mode) const override {
+    if (h265_supported_ &&
+        absl::EqualsIgnoreCase(format.name, kH265CodecName)) {
+      return {.is_supported = true, .is_power_efficient = true};
+    }
+    return builtin_->QueryCodecSupport(format, scalability_mode);
+  }
+
+ private:
+  std::unique_ptr<VideoEncoderFactory> builtin_;
+  bool h265_supported_;
+};
+
+// ------- Decoder factory -------
+
+class WmfH265VideoDecoderFactory : public VideoDecoderFactory {
+ public:
+  explicit WmfH265VideoDecoderFactory(
+      std::unique_ptr<VideoDecoderFactory> builtin)
+      : builtin_(std::move(builtin)),
+        h265_supported_(WmfH265Decoder::IsSupported()) {
+    if (h265_supported_) {
+      RTC_LOG(LS_INFO) << "WMF H.265 decoder is available.";
+    } else {
+      RTC_LOG(LS_WARNING) << "WMF H.265 decoder is NOT available.";
+    }
+  }
+
+  std::unique_ptr<VideoDecoder> Create(const Environment& env,
+                                       const SdpVideoFormat& format) override {
+    if (h265_supported_ &&
+        absl::EqualsIgnoreCase(format.name, kH265CodecName)) {
+      auto decoder = WmfH265Decoder::Create();
+      if (decoder) {
+        return decoder;
+      }
+      RTC_LOG(LS_WARNING)
+          << "Failed to create WMF H.265 decoder, no fallback available.";
+      return nullptr;
+    }
+    return builtin_->Create(env, format);
+  }
+
+  std::vector<SdpVideoFormat> GetSupportedFormats() const override {
+    auto formats = builtin_->GetSupportedFormats();
+    if (h265_supported_) {
+      auto h265_formats = GetSupportedH265Formats();
+      formats.insert(formats.end(), h265_formats.begin(),
+                     h265_formats.end());
+    }
+    return formats;
+  }
+
+  CodecSupport QueryCodecSupport(
+      const SdpVideoFormat& format,
+      bool reference_scaling) const override {
+    if (h265_supported_ &&
+        absl::EqualsIgnoreCase(format.name, kH265CodecName)) {
+      return {.is_supported = true, .is_power_efficient = true};
+    }
+    return builtin_->QueryCodecSupport(format, reference_scaling);
+  }
+
+ private:
+  std::unique_ptr<VideoDecoderFactory> builtin_;
+  bool h265_supported_;
+};
+
+}  // namespace
+
+std::unique_ptr<VideoEncoderFactory> CreateWmfH265EncoderFactory(
+    std::unique_ptr<VideoEncoderFactory> builtin) {
+  return std::make_unique<WmfH265VideoEncoderFactory>(std::move(builtin));
+}
+
+std::unique_ptr<VideoDecoderFactory> CreateWmfH265DecoderFactory(
+    std::unique_ptr<VideoDecoderFactory> builtin) {
+  return std::make_unique<WmfH265VideoDecoderFactory>(std::move(builtin));
+}
+
+}  // namespace webrtc

--- a/src/win/wmf_h265_factory.h
+++ b/src/win/wmf_h265_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024 libwebrtc project authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef LIB_WEBRTC_WIN_WMF_H265_FACTORY_H_
+#define LIB_WEBRTC_WIN_WMF_H265_FACTORY_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_decoder.h"
+#include "api/video_codecs/video_decoder_factory.h"
+#include "api/video_codecs/video_encoder.h"
+#include "api/video_codecs/video_encoder_factory.h"
+
+namespace webrtc {
+
+// Creates a video encoder factory that adds H.265 hardware encoding
+// (via Windows Media Foundation) on top of the builtin encoder factory.
+std::unique_ptr<VideoEncoderFactory>
+CreateWmfH265EncoderFactory(std::unique_ptr<VideoEncoderFactory> builtin);
+
+// Creates a video decoder factory that adds H.265 hardware decoding
+// (via Windows Media Foundation) on top of the builtin decoder factory.
+std::unique_ptr<VideoDecoderFactory>
+CreateWmfH265DecoderFactory(std::unique_ptr<VideoDecoderFactory> builtin);
+
+}  // namespace webrtc
+
+#endif  // LIB_WEBRTC_WIN_WMF_H265_FACTORY_H_


### PR DESCRIPTION
## Summary

Add H.265 (HEVC) hardware-accelerated encoding and decoding support on Windows
using the Media Foundation Transform (MFT) pipeline. This enables H.265 codec
negotiation and media processing through the OS-provided HEVC MFTs, which
delegate to GPU vendor hardware (NVENC/NVDEC, Intel QSV, AMD AMF) transparently.

## Motivation

WebRTC M137 includes H.265 SDP/RTP infrastructure (`rtc_use_h265=true`) but
ships no encoder/decoder implementations. This PR fills that gap on Windows
without introducing any third-party codec dependencies.

## Changes

### New files (`src/win/`)
- `wmf_h265_encoder.h/.cc` — `VideoEncoder` implementation using HEVC encoder MFT
- `wmf_h265_decoder.h/.cc` — `VideoDecoder` implementation using HEVC decoder MFT
- `wmf_h265_factory.h/.cc` — Decorator factories that add H.265 to the builtin codec list

### Modified files
- `BUILD.gn` — Conditionally compile WMF sources when `is_win && !libwebrtc_intel_media_sdk && rtc_use_h265`
- `src/rtc_peerconnection_factory_impl.cc` — Wire WMF factories into `CreatePeerConnectionFactory`

## Implementation details

- **Codec discovery**: `MFTEnumEx` with `MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER` to prefer HW-accelerated MFTs
- **Pixel format**: I420 → NV12 conversion via libyuv (input), NV12/I420 → I420 (output)
- **Rate control**: CBR mode via `CODECAPI_AVEncCommonRateControlMode`; dynamic bitrate updates via `CODECAPI_AVEncCommonMeanBitRate`
- **Keyframe requests**: Forced IDR via `CODECAPI_AVEncVideoForceKeyFrame`
- **Low latency**: `MF_LOW_LATENCY` attribute set on both encoder and decoder MFTs
- **QP reporting**: `H265BitstreamParser` extracts per-frame QP into `EncodedImage::qp_`
- **Resolution alignment**: Reports `requested_resolution_alignment = 2` (NV12 requirement)
- **COM safety**: `CoInitializeEx` is called in `IsSupported()` and `InitMediaFoundation()` so the code works regardless of whether the calling thread has COM initialized
- **Dynamic resolution change**: Decoder handles `MF_E_TRANSFORM_STREAM_CHANGE` and updates cached dimensions from the new output media type
- **SDP parameters**: Advertises Main profile (`profile-id=1`), Main tier (`tier-flag=0`), Level 4.0 (`level-id=120`)
- **Hardware acceleration**: Both `GetEncoderInfo()` and `GetDecoderInfo()` report `is_hardware_accelerated = true`

## Build flags
`rtc_use_h265=true`
`proprietary_codecs=true`
`ffmpeg_branding="Chrome"`

No additional flags required. The WMF path activates automatically on Windows when `libwebrtc_intel_media_sdk` is not set (default).

## Requirements

- Windows 10 1709+ with HEVC Video Extensions (free from Microsoft Store for OEMs, or $0.99 for HEVC Video Extensions from Device Manufacturer)
- GPU with HEVC encode/decode support (NVIDIA Kepler+, Intel Skylake+, AMD Polaris+)