### PR TITLE
feat: add custom video source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+build
+libs

--- a/examples/wx_loop_back_demo/CMakeLists.txt
+++ b/examples/wx_loop_back_demo/CMakeLists.txt
@@ -69,7 +69,7 @@ if(APPLE)
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
         MACOSX_BUNDLE_BUNDLE_NAME "wx_loop_back_demo"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "io.livekit.wx_loop_back_demo"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.webrtc-sdk.libwebrtc.wx_loop_back_demo"
         MACOSX_BUNDLE_BUNDLE_VERSION "1.0"
         MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
         BUILD_RPATH   "@executable_path/../Frameworks"

--- a/examples/wx_loop_back_demo/CMakeLists.txt
+++ b/examples/wx_loop_back_demo/CMakeLists.txt
@@ -1,0 +1,118 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(wx_loop_back_demo CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Locate libwebrtc relative to this example directory:
+#   <libwebrtc>/examples/wx_loop_back_demo/  <- CMAKE_CURRENT_SOURCE_DIR
+#   <libwebrtc>/include/
+#   <libwebrtc>/libs/libwebrtc.so
+set(LIBWEBRTC_ROOT     "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(LIBWEBRTC_INCLUDE  "${LIBWEBRTC_ROOT}/include")
+
+if(WIN32)
+    set(LIBWEBRTC_LIBRARY "${LIBWEBRTC_ROOT}/libs/libwebrtc.lib")
+elseif(APPLE)
+    set(LIBWEBRTC_LIBRARY "${LIBWEBRTC_ROOT}/libs/libwebrtc.dylib")
+else()
+    set(LIBWEBRTC_LIBRARY "${LIBWEBRTC_ROOT}/libs/libwebrtc.so")
+endif()
+
+if(NOT EXISTS "${LIBWEBRTC_LIBRARY}")
+    message(FATAL_ERROR
+        "libwebrtc shared library not found at: ${LIBWEBRTC_LIBRARY}\n"
+        "Build libwebrtc first or place the prebuilt binary under "
+        "${LIBWEBRTC_ROOT}/libs/.")
+endif()
+
+# --- wxWidgets ---------------------------------------------------------------
+# Prefer the modern CONFIG package shipped by wxWidgets >= 3.2 (provides
+# imported targets wx::core, wx::base). Fall back to the legacy module-mode
+# find_package, which sets wxWidgets_INCLUDE_DIRS / wxWidgets_LIBRARIES.
+
+find_package(wxWidgets CONFIG QUIET COMPONENTS core base)
+
+if(NOT wxWidgets_FOUND)
+    find_package(wxWidgets REQUIRED COMPONENTS core base)
+    include(${wxWidgets_USE_FILE})
+endif()
+
+# --- Target ------------------------------------------------------------------
+add_executable(wx_loop_back_demo WIN32 MACOSX_BUNDLE main.cc)
+
+target_include_directories(wx_loop_back_demo PRIVATE
+    ${LIBWEBRTC_INCLUDE}
+)
+
+# Mirror the macros libwebrtc was built with, otherwise headers like
+# rtc_peerconnection_factory.h compile away the desktop-capture surface and
+# we'd be missing GetDesktopDevice / CreateDesktopSource etc.
+target_compile_definitions(wx_loop_back_demo PRIVATE RTC_DESKTOP_DEVICE)
+
+if(TARGET wx::core)
+    target_link_libraries(wx_loop_back_demo PRIVATE wx::core wx::base)
+else()
+    target_include_directories(wx_loop_back_demo PRIVATE ${wxWidgets_INCLUDE_DIRS})
+    target_compile_definitions(wx_loop_back_demo PRIVATE ${wxWidgets_DEFINITIONS})
+    target_link_libraries(wx_loop_back_demo PRIVATE ${wxWidgets_LIBRARIES})
+endif()
+
+target_link_libraries(wx_loop_back_demo PRIVATE ${LIBWEBRTC_LIBRARY})
+
+if(APPLE)
+    # On macOS, embed libwebrtc.dylib inside the .app bundle's Frameworks/
+    # directory and resolve it at runtime via @rpath, so the bundle is
+    # self-contained and can be launched from anywhere.
+    set_target_properties(wx_loop_back_demo PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
+        MACOSX_BUNDLE_BUNDLE_NAME "wx_loop_back_demo"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "io.livekit.wx_loop_back_demo"
+        MACOSX_BUNDLE_BUNDLE_VERSION "1.0"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
+        BUILD_RPATH   "@executable_path/../Frameworks"
+        INSTALL_RPATH "@executable_path/../Frameworks"
+    )
+
+    find_library(APPLICATION_SERVICES ApplicationServices)
+    find_library(AUDIO_TOOLBOX AudioToolbox)
+    find_library(AV_FOUNDATION AVFoundation)
+    find_library(CORE_AUDIO CoreAudio)
+    find_library(CORE_FOUNDATION Foundation)
+    find_library(CORE_MEDIA CoreMedia)
+    find_library(CORE_VIDEO CoreVideo)
+    find_library(CORE_SERVICES CoreServices)
+
+    target_link_libraries(wx_loop_back_demo PRIVATE
+        ${APPLICATION_SERVICES}
+        ${AUDIO_TOOLBOX}
+        ${AV_FOUNDATION}
+        ${CORE_AUDIO}
+        ${CORE_FOUNDATION}
+        ${CORE_MEDIA}
+        ${CORE_VIDEO}
+        ${CORE_SERVICES}
+    )
+
+    # Post-build: copy the dylib into the bundle, rewrite the executable's
+    # recorded dependency to @rpath/libwebrtc.dylib (the source library may
+    # be linked under any install_name — `./libwebrtc.dylib`, an absolute
+    # path, etc., so the rewrite is computed from `otool -L` at runtime),
+    # then ad-hoc re-sign so recent macOS will load the modified binaries.
+    add_custom_command(TARGET wx_loop_back_demo POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DLIBWEBRTC_LIBRARY=${LIBWEBRTC_LIBRARY}
+            -DBUNDLE_DIR=$<TARGET_BUNDLE_DIR:wx_loop_back_demo>
+            -DEXE_PATH=$<TARGET_FILE:wx_loop_back_demo>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/embed_libwebrtc.cmake
+        COMMENT "Embedding libwebrtc.dylib into wx_loop_back_demo.app"
+    )
+else()
+    # Non-Apple: keep the build tree pointing at libs/ for direct execution.
+    set_target_properties(wx_loop_back_demo PROPERTIES
+        BUILD_RPATH   "${LIBWEBRTC_ROOT}/libs"
+        INSTALL_RPATH "${LIBWEBRTC_ROOT}/libs"
+    )
+endif()

--- a/examples/wx_loop_back_demo/Info.plist.in
+++ b/examples/wx_loop_back_demo/Info.plist.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app needs access to the microphone to demonstrate the libwebrtc audio loopback.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>This app needs access to the camera to demonstrate libwebrtc video capture.</string>
+</dict>
+</plist>

--- a/examples/wx_loop_back_demo/README.md
+++ b/examples/wx_loop_back_demo/README.md
@@ -105,16 +105,9 @@ otool -l build/wx_loop_back_demo.app/Contents/MacOS/wx_loop_back_demo \
 ### Resetting macOS TCC permissions while iterating
 
 ```bash
-tccutil reset Microphone io.livekit.wx_loop_back_demo
-tccutil reset Camera     io.livekit.wx_loop_back_demo
+tccutil reset Microphone io.github.webrtc-sdk.libwebrtc.wx_loop_back_demo
+tccutil reset Camera     io.github.webrtc-sdk.libwebrtc.wx_loop_back_demo
 ```
-
-### Debugging in VSCode
-
-A launch configuration `(lldb) 调试 wx_loop_back_demo` is provided in
-[`<repo>/src/.vscode/launch.json`](../../../../.vscode/launch.json); F5
-builds (via the `build wx_loop_back_demo` task) and attaches lldb to the
-bundle's executable.
 
 ## Troubleshooting
 

--- a/examples/wx_loop_back_demo/README.md
+++ b/examples/wx_loop_back_demo/README.md
@@ -33,7 +33,7 @@ and the remote video is rendered into the window.
 This demo depends on three libwebrtc additions:
 
 - `RTCVideoSource::OnCapturedFrame(scoped_refptr<RTCVideoFrame>)` — push user-supplied frames.
-- `RTCPeerConnectionFactory::CreateCustomVideoCapturer()` — capturer not bound to any device.
+- `RTCPeerConnectionFactory::CreateCustomVideoSource(...)` — custom video source not bound to any device.
 - `internal::VideoCapturer::OnFrame` made public so the source can forward into the broadcaster.
 
 They ship in the current source tree but are **not** in older prebuilt

--- a/examples/wx_loop_back_demo/README.md
+++ b/examples/wx_loop_back_demo/README.md
@@ -1,0 +1,124 @@
+# wx_loop_back_demo
+
+A wxWidgets desktop demo that exercises the libwebrtc C++ API end-to-end:
+two in-process `RTCPeerConnection`s negotiate over a fake signaling channel,
+an audio track plus a synthetic 640×480 colour-bars video track loop back,
+and the remote video is rendered into the window.
+
+```
++-----------+   offer/answer + ICE candidates    +-----------+
+|  offerer  |  <-------------------------------> |  answerer |
++-----------+                                    +-----------+
+      |                                                |
+      | AddTrack (audio + colour-bars video)           |
+      |                                                v
+      |                                  RTCVideoTrack -> AddRenderer
+      |                                                |
+      v                                                v
+ OnCapturedFrame()                          VideoSinkRenderer ->
+ (synthetic frames)                         wxImage -> wxBitmap -> Panel
+```
+
+## Prerequisites
+
+| Component | Notes |
+|---|---|
+| `libwebrtc.dylib` (macOS) / `.so` (Linux) / `.lib` + `.dll` (Windows) | Built from this repo, placed in `<repo>/src/libwebrtc/libs/`. The demo links the prebuilt artifact rather than the source tree. |
+| wxWidgets ≥ 3.2 | `brew install wxwidgets` on macOS, `apt install libwxgtk3.2-dev` on Debian/Ubuntu, [official installer](https://www.wxwidgets.org/downloads/) on Windows. |
+| CMake ≥ 3.16 | |
+| C++17 toolchain | clang/AppleClang/GCC/MSVC all fine. |
+
+## 1. Build / refresh `libwebrtc.dylib`
+
+This demo depends on three libwebrtc additions:
+
+- `RTCVideoSource::OnCapturedFrame(scoped_refptr<RTCVideoFrame>)` — push user-supplied frames.
+- `RTCPeerConnectionFactory::CreateCustomVideoCapturer()` — capturer not bound to any device.
+- `internal::VideoCapturer::OnFrame` made public so the source can forward into the broadcaster.
+
+They ship in the current source tree but are **not** in older prebuilt
+binaries. Rebuild the dylib and copy it in before building the demo:
+
+```bash
+# from <repo root>
+./lk_dynamic_build.sh                               # or whichever GN/Ninja wrapper applies
+cp out-debug/macOS-arm64/libwebrtc.dylib src/libwebrtc/libs/
+```
+
+> Skipping this step → demo links the old dylib → vtable mismatch → either
+> silent no-op video or a runtime crash on `OnCapturedFrame`.
+
+## 2. Build the demo
+
+From this directory:
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+A post-build step ([`embed_libwebrtc.cmake`](embed_libwebrtc.cmake)) copies
+`libwebrtc.dylib` into `wx_loop_back_demo.app/Contents/Frameworks/`,
+rewrites the executable's recorded dependency to `@rpath/libwebrtc.dylib`,
+and ad-hoc re-signs both binaries (required on Apple Silicon).
+
+## 3. Run
+
+```bash
+open build/wx_loop_back_demo.app          # macOS
+./build/wx_loop_back_demo                 # Linux / Windows
+```
+
+## 4. Test plan
+
+After the window opens, click **Start loopback** and verify:
+
+| Check | Expected |
+|---|---|
+| First-run permission prompt (macOS) | macOS asks for **microphone** access. Grant it. The demo doesn't open a real camera, so no camera prompt should appear. |
+| Status label | `Idle.` → `Starting...` → `Loopback running. See log below.` |
+| Log — state transitions | `LibWebRTC::Initialize`, then state lines using enum names, e.g.<br>`[offerer] signaling state -> HaveLocalOffer`<br>`[answerer] signaling state -> HaveRemoteOffer`<br>`[answerer] signaling state -> Stable`<br>`[offerer] signaling state -> Stable`<br>`[offerer/answerer] ice gathering -> Gathering -> Complete`<br>`[offerer/answerer] ice connection -> Checking -> Connected -> Completed`<br>`[offerer/answerer] pc state -> Connecting -> Connected`<br>`[answerer] OnAddTrack (kind=AUDIO)`<br>`[answerer] OnAddTrack (kind=VIDEO)`<br>`[answerer] attached video sink renderer` |
+| Video panel | 8 SMPTE colour bars (white / yellow / cyan / green / magenta / red / blue / black) **scrolling horizontally** at ~120 px/sec, scaled to fit the left half of the window. |
+| Periodic log | `[pusher] color bars frame #N (scroll=…)` every 2 s; `[remote video] frame #N: 640x480` every 30 frames — both ends of the pipeline are flowing. |
+| Click **Stop** | Status flips to `Stopped.`, log stops growing, video panel freezes on its last frame, `Start loopback` becomes available again. |
+| Close the window | No crash, no zombie threads (`TeardownLoopback` joins the pusher thread before releasing the PCs / factory). |
+
+### CLI sanity checks (macOS)
+
+After step 2, verify the bundle was assembled correctly:
+
+```bash
+# embedded dylib is present
+ls build/wx_loop_back_demo.app/Contents/Frameworks/libwebrtc.dylib
+
+# executable resolves libwebrtc via @rpath, not the source path
+otool -L build/wx_loop_back_demo.app/Contents/MacOS/wx_loop_back_demo \
+  | grep webrtc
+# → @rpath/libwebrtc.dylib
+
+# rpath points inside the bundle
+otool -l build/wx_loop_back_demo.app/Contents/MacOS/wx_loop_back_demo \
+  | grep -A2 LC_RPATH
+# → @executable_path/../Frameworks
+```
+
+### Resetting macOS TCC permissions while iterating
+
+```bash
+tccutil reset Microphone io.livekit.wx_loop_back_demo
+tccutil reset Camera     io.livekit.wx_loop_back_demo
+```
+
+### Debugging in VSCode
+
+A launch configuration `(lldb) 调试 wx_loop_back_demo` is provided in
+[`<repo>/src/.vscode/launch.json`](../../../../.vscode/launch.json); F5
+builds (via the `build wx_loop_back_demo` task) and attaches lldb to the
+bundle's executable.
+
+## Troubleshooting
+
+- **`libwebrtc shared library not found at: …/libs/libwebrtc.dylib`** — step 1 wasn't run, or the artifact is in a different `out-*` directory. Copy it into `<repo>/src/libwebrtc/libs/`.
+- **Black video panel, log shows `OnAddTrack (kind=VIDEO)` but no `[remote video] frame #…`** — almost always means the dylib is still the old one without `OnCapturedFrame`. Rebuild the dylib (step 1) and the demo (step 2).
+- **`pc state -> Failed`, no audio/video loopback** — on hosts with very strict firewalls add a STUN server to `RTCConfiguration::ice_servers` in `MainFrame::OnStart`.
+- **`install_name_tool` errors during the post-build step** — ensure Xcode CLT is installed (`xcode-select --install`).

--- a/examples/wx_loop_back_demo/embed_libwebrtc.cmake
+++ b/examples/wx_loop_back_demo/embed_libwebrtc.cmake
@@ -1,0 +1,63 @@
+# Embed libwebrtc.dylib into a macOS .app bundle.
+#
+# Required arguments (passed via -D on the cmake -P invocation):
+#   LIBWEBRTC_LIBRARY - source dylib to copy in
+#   BUNDLE_DIR        - <something>.app
+#   EXE_PATH          - main executable inside the bundle
+
+if(NOT LIBWEBRTC_LIBRARY OR NOT BUNDLE_DIR OR NOT EXE_PATH)
+    message(FATAL_ERROR "embed_libwebrtc.cmake: missing required arguments")
+endif()
+
+set(FRAMEWORKS_DIR "${BUNDLE_DIR}/Contents/Frameworks")
+set(EMBEDDED       "${FRAMEWORKS_DIR}/libwebrtc.dylib")
+
+file(MAKE_DIRECTORY "${FRAMEWORKS_DIR}")
+configure_file("${LIBWEBRTC_LIBRARY}" "${EMBEDDED}" COPYONLY)
+
+# Make the embedded copy resolve via @rpath.
+execute_process(
+    COMMAND install_name_tool -id "@rpath/libwebrtc.dylib" "${EMBEDDED}"
+    RESULT_VARIABLE rc
+)
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "install_name_tool -id failed (${rc})")
+endif()
+
+# Discover whatever path the executable currently records for libwebrtc and
+# rewrite it to @rpath/libwebrtc.dylib. The source dylib may have any
+# install_name (./libwebrtc.dylib, an absolute path, etc.), so we can't
+# hard-code the -change source.
+execute_process(
+    COMMAND otool -L "${EXE_PATH}"
+    OUTPUT_VARIABLE OTOOL_OUT
+    RESULT_VARIABLE rc
+)
+if(NOT rc EQUAL 0)
+    message(FATAL_ERROR "otool -L ${EXE_PATH} failed (${rc})")
+endif()
+
+string(REPLACE "\n" ";" OTOOL_LINES "${OTOOL_OUT}")
+foreach(line IN LISTS OTOOL_LINES)
+    if(line MATCHES "libwebrtc[^/ ]*\\.dylib")
+        string(STRIP "${line}" stripped)
+        # Each dependency line is "<path> (compatibility version ...)" — take
+        # the path up to the first space.
+        string(REGEX REPLACE " \\(compatibility.*$" "" dep "${stripped}")
+        if(NOT dep STREQUAL "@rpath/libwebrtc.dylib")
+            message(STATUS "Rewriting executable dependency: ${dep} -> @rpath/libwebrtc.dylib")
+            execute_process(
+                COMMAND install_name_tool -change "${dep}"
+                        "@rpath/libwebrtc.dylib" "${EXE_PATH}"
+                RESULT_VARIABLE rc
+            )
+            if(NOT rc EQUAL 0)
+                message(FATAL_ERROR "install_name_tool -change failed (${rc})")
+            endif()
+        endif()
+    endif()
+endforeach()
+
+# Re-sign — install_name_tool invalidates the existing signature.
+execute_process(COMMAND codesign --force --sign - "${EMBEDDED}")
+execute_process(COMMAND codesign --force --sign - "${BUNDLE_DIR}")

--- a/examples/wx_loop_back_demo/main.cc
+++ b/examples/wx_loop_back_demo/main.cc
@@ -1,0 +1,694 @@
+// Simple wxWidgets demo that exercises libwebrtc's loopback path through the
+// C++ API: two in-process RTCPeerConnections negotiate over a fake signaling
+// channel and stream a single audio track from one to the other.
+
+#include <wx/wx.h>
+#include <wx/textctrl.h>
+#include <wx/sizer.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include "libwebrtc.h"
+#include "rtc_peerconnection.h"
+#include "rtc_peerconnection_factory.h"
+#include "rtc_mediaconstraints.h"
+#include "rtc_ice_candidate.h"
+#include "rtc_audio_source.h"
+#include "rtc_audio_track.h"
+#include "rtc_rtp_sender.h"
+#include "rtc_rtp_transceiver.h"
+#include "rtc_media_stream.h"
+#include "rtc_data_channel.h"
+#include "rtc_rtp_receiver.h"
+#include "rtc_video_device.h"
+#include "rtc_video_source.h"
+#include "rtc_video_track.h"
+#include "rtc_video_frame.h"
+#include "rtc_video_renderer.h"
+#include "rtc_media_track.h"
+
+using libwebrtc::scoped_refptr;
+using libwebrtc::string;
+
+namespace {
+
+// Marshals log messages to the wxTextCtrl on the UI thread regardless of
+// which libwebrtc thread emits them.
+class UiLogger {
+public:
+    explicit UiLogger(wxTextCtrl* sink) : sink_(sink) {}
+
+    void Log(const wxString& message) {
+        wxTextCtrl* sink = sink_;
+        if (wxIsMainThread()) {
+            sink->AppendText(message + "\n");
+        } else {
+            wxString copy = message;
+            sink->GetEventHandler()->CallAfter([sink, copy] {
+                sink->AppendText(copy + "\n");
+            });
+        }
+    }
+
+private:
+    wxTextCtrl* sink_;
+};
+
+UiLogger* g_logger = nullptr;
+
+void Log(const char* fmt, ...) {
+    if (!g_logger) return;
+    char buf[1024];
+    va_list ap;
+    va_start(ap, fmt);
+    std::vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    g_logger->Log(wxString::FromUTF8(buf));
+}
+
+// Enum -> human-readable name. Keeps log lines greppable.
+const char* ToString(libwebrtc::RTCSignalingState s) {
+    switch (s) {
+        case libwebrtc::RTCSignalingStateStable:             return "Stable";
+        case libwebrtc::RTCSignalingStateHaveLocalOffer:     return "HaveLocalOffer";
+        case libwebrtc::RTCSignalingStateHaveRemoteOffer:    return "HaveRemoteOffer";
+        case libwebrtc::RTCSignalingStateHaveLocalPrAnswer:  return "HaveLocalPrAnswer";
+        case libwebrtc::RTCSignalingStateHaveRemotePrAnswer: return "HaveRemotePrAnswer";
+        case libwebrtc::RTCSignalingStateClosed:             return "Closed";
+    }
+    return "?";
+}
+
+const char* ToString(libwebrtc::RTCPeerConnectionState s) {
+    switch (s) {
+        case libwebrtc::RTCPeerConnectionStateNew:          return "New";
+        case libwebrtc::RTCPeerConnectionStateConnecting:   return "Connecting";
+        case libwebrtc::RTCPeerConnectionStateConnected:    return "Connected";
+        case libwebrtc::RTCPeerConnectionStateDisconnected: return "Disconnected";
+        case libwebrtc::RTCPeerConnectionStateFailed:       return "Failed";
+        case libwebrtc::RTCPeerConnectionStateClosed:       return "Closed";
+    }
+    return "?";
+}
+
+const char* ToString(libwebrtc::RTCIceGatheringState s) {
+    switch (s) {
+        case libwebrtc::RTCIceGatheringStateNew:       return "New";
+        case libwebrtc::RTCIceGatheringStateGathering: return "Gathering";
+        case libwebrtc::RTCIceGatheringStateComplete:  return "Complete";
+    }
+    return "?";
+}
+
+const char* ToString(libwebrtc::RTCIceConnectionState s) {
+    switch (s) {
+        case libwebrtc::RTCIceConnectionStateNew:          return "New";
+        case libwebrtc::RTCIceConnectionStateChecking:     return "Checking";
+        case libwebrtc::RTCIceConnectionStateCompleted:    return "Completed";
+        case libwebrtc::RTCIceConnectionStateConnected:    return "Connected";
+        case libwebrtc::RTCIceConnectionStateFailed:       return "Failed";
+        case libwebrtc::RTCIceConnectionStateDisconnected: return "Disconnected";
+        case libwebrtc::RTCIceConnectionStateClosed:       return "Closed";
+        case libwebrtc::RTCIceConnectionStateMax:          return "Max";
+    }
+    return "?";
+}
+
+const char* ToString(libwebrtc::RTCMediaType t) {
+    switch (t) {
+        case libwebrtc::RTCMediaType::AUDIO:       return "AUDIO";
+        case libwebrtc::RTCMediaType::VIDEO:       return "VIDEO";
+        case libwebrtc::RTCMediaType::DATA:        return "DATA";
+        case libwebrtc::RTCMediaType::UNSUPPORTED: return "UNSUPPORTED";
+    }
+    return "?";
+}
+
+class PeerSlot;
+
+// Custom panel that displays the latest decoded video frame, scaled to fit
+// the panel client area. The image is updated from the libwebrtc decoder
+// thread via UpdateFrame; the actual rasterisation happens in OnPaint on the
+// UI thread.
+class VideoRenderPanel : public wxPanel {
+public:
+    VideoRenderPanel(wxWindow* parent)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240)) {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetBackgroundColour(*wxBLACK);
+        Bind(wxEVT_PAINT, &VideoRenderPanel::OnPaint, this);
+    }
+
+    // Thread-safe: takes the wxImage by value, marshals to UI thread.
+    void UpdateFrame(wxImage image) {
+        if (wxIsMainThread()) {
+            latest_image_ = std::move(image);
+            Refresh(false);
+            return;
+        }
+        wxImage captured = std::move(image);
+        GetEventHandler()->CallAfter(
+            [this, captured = std::move(captured)]() mutable {
+                latest_image_ = std::move(captured);
+                Refresh(false);
+            });
+    }
+
+private:
+    void OnPaint(wxPaintEvent&) {
+        wxPaintDC dc(this);
+        wxSize sz = GetClientSize();
+        if (sz.x <= 0 || sz.y <= 0) return;
+        if (!latest_image_.IsOk()) {
+            dc.SetBackground(*wxBLACK_BRUSH);
+            dc.Clear();
+            return;
+        }
+        wxImage scaled = (latest_image_.GetWidth() != sz.x ||
+                          latest_image_.GetHeight() != sz.y)
+                             ? latest_image_.Scale(sz.x, sz.y,
+                                                   wxIMAGE_QUALITY_NEAREST)
+                             : latest_image_;
+        dc.DrawBitmap(wxBitmap(scaled), 0, 0);
+    }
+
+    wxImage latest_image_;  // touched only on UI thread
+};
+
+// RTCVideoRenderer adapter that converts each decoded I420 frame into a
+// wxImage and hands it to a VideoRenderPanel for display. Also keeps a
+// running count for diagnostic logging.
+class VideoSinkRenderer
+    : public libwebrtc::RTCVideoRenderer<scoped_refptr<libwebrtc::RTCVideoFrame>> {
+public:
+    explicit VideoSinkRenderer(VideoRenderPanel* panel) : panel_(panel) {}
+
+    void OnFrame(scoped_refptr<libwebrtc::RTCVideoFrame> frame) override {
+        if (!frame || !panel_) return;
+        const int w = frame->width();
+        const int h = frame->height();
+        if (w <= 0 || h <= 0) return;
+
+        // libyuv::I420ToABGR places bytes in memory as R, G, B, A — exactly
+        // the order wxImage's RGB buffer wants for the first three.
+        std::vector<uint8_t> abgr(static_cast<size_t>(w) * h * 4);
+        frame->ConvertToARGB(libwebrtc::RTCVideoFrame::Type::kABGR,
+                             abgr.data(), w * 4, w, h);
+
+        // wxImage requires its data pointer to be malloc()'d so it can free()
+        // on destruction. Strip the alpha channel as we copy.
+        unsigned char* rgb =
+            static_cast<unsigned char*>(std::malloc(static_cast<size_t>(w) * h * 3));
+        if (!rgb) return;
+        for (int i = 0; i < w * h; ++i) {
+            rgb[i * 3 + 0] = abgr[i * 4 + 0];
+            rgb[i * 3 + 1] = abgr[i * 4 + 1];
+            rgb[i * 3 + 2] = abgr[i * 4 + 2];
+        }
+        wxImage image(w, h, rgb);  // takes ownership
+
+        size_t n = ++count_;
+        if (n == 1 || n % 30 == 0) {
+            Log("[remote video] frame #%zu: %dx%d", n, w, h);
+        }
+        panel_->UpdateFrame(std::move(image));
+    }
+
+private:
+    VideoRenderPanel* panel_;
+    std::atomic<size_t> count_{0};
+};
+
+// Observer attached to one peer; forwards ICE candidates to the loopback peer
+// and reports state changes to the UI log.
+class LoopbackObserver : public libwebrtc::RTCPeerConnectionObserver {
+public:
+    LoopbackObserver(PeerSlot* slot, VideoRenderPanel* render_panel = nullptr)
+        : slot_(slot), render_panel_(render_panel) {}
+
+    void OnSignalingState(libwebrtc::RTCSignalingState state) override;
+    void OnPeerConnectionState(libwebrtc::RTCPeerConnectionState state) override;
+    void OnIceGatheringState(libwebrtc::RTCIceGatheringState state) override;
+    void OnIceConnectionState(libwebrtc::RTCIceConnectionState state) override;
+    void OnIceCandidate(scoped_refptr<libwebrtc::RTCIceCandidate> candidate) override;
+    void OnAddStream(scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
+    void OnRemoveStream(scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
+    void OnDataChannel(scoped_refptr<libwebrtc::RTCDataChannel> /*dc*/) override {}
+    void OnRenegotiationNeeded() override {}
+    void OnTrack(scoped_refptr<libwebrtc::RTCRtpTransceiver> /*t*/) override {}
+    void OnAddTrack(libwebrtc::vector<scoped_refptr<libwebrtc::RTCMediaStream>> /*streams*/,
+                    scoped_refptr<libwebrtc::RTCRtpReceiver> receiver) override;
+    void OnRemoveTrack(scoped_refptr<libwebrtc::RTCRtpReceiver> /*receiver*/) override {}
+
+private:
+    PeerSlot* slot_;
+    VideoRenderPanel* render_panel_;
+};
+
+// Holds the state of a single peer in the loopback pair.
+class PeerSlot {
+public:
+    PeerSlot(const char* tag) : tag_(tag) {}
+
+    const char* tag() const { return tag_; }
+
+    scoped_refptr<libwebrtc::RTCPeerConnection> pc;
+    PeerSlot* remote = nullptr;
+    std::atomic<bool> closed{false};
+    std::unique_ptr<LoopbackObserver> observer;
+
+    // Filled in when the remote side receives a video track. The track ref
+    // keeps the underlying object alive for as long as we have a renderer
+    // attached to it.
+    scoped_refptr<libwebrtc::RTCVideoTrack> remote_video_track;
+    std::unique_ptr<VideoSinkRenderer> remote_video_renderer;
+
+private:
+    const char* tag_;
+};
+
+void LoopbackObserver::OnSignalingState(libwebrtc::RTCSignalingState state) {
+    Log("[%s] signaling state -> %s", slot_->tag(), ToString(state));
+}
+
+void LoopbackObserver::OnPeerConnectionState(
+    libwebrtc::RTCPeerConnectionState state) {
+    Log("[%s] pc state -> %s", slot_->tag(), ToString(state));
+}
+
+void LoopbackObserver::OnIceGatheringState(
+    libwebrtc::RTCIceGatheringState state) {
+    Log("[%s] ice gathering -> %s", slot_->tag(), ToString(state));
+}
+
+void LoopbackObserver::OnIceConnectionState(
+    libwebrtc::RTCIceConnectionState state) {
+    Log("[%s] ice connection -> %s", slot_->tag(), ToString(state));
+}
+
+void LoopbackObserver::OnIceCandidate(
+    scoped_refptr<libwebrtc::RTCIceCandidate> candidate) {
+    if (!candidate) return;
+    PeerSlot* remote = slot_->remote;
+    if (!remote || remote->closed.load() || !remote->pc) return;
+
+    Log("[%s] -> [%s] candidate (mid=%s, mline=%d)", slot_->tag(),
+        remote->tag(), candidate->sdp_mid().c_string(),
+        candidate->sdp_mline_index());
+
+    remote->pc->AddCandidate(candidate->sdp_mid(),
+                             candidate->sdp_mline_index(),
+                             candidate->candidate());
+}
+
+void LoopbackObserver::OnAddTrack(
+    libwebrtc::vector<scoped_refptr<libwebrtc::RTCMediaStream>> /*streams*/,
+    scoped_refptr<libwebrtc::RTCRtpReceiver> receiver) {
+    if (!receiver) return;
+    Log("[%s] OnAddTrack (kind=%s)", slot_->tag(),
+        ToString(receiver->media_type()));
+
+    if (receiver->media_type() != libwebrtc::RTCMediaType::VIDEO) return;
+
+    scoped_refptr<libwebrtc::RTCMediaTrack> media = receiver->track();
+    if (!media) return;
+
+    // Down-cast: when media_type is VIDEO the underlying track is a
+    // RTCVideoTrack, which is the only subclass of RTCMediaTrack that exposes
+    // AddRenderer/RemoveRenderer.
+    auto* video_ptr = static_cast<libwebrtc::RTCVideoTrack*>(media.get());
+    slot_->remote_video_track =
+        scoped_refptr<libwebrtc::RTCVideoTrack>(video_ptr);
+    slot_->remote_video_renderer =
+        std::make_unique<VideoSinkRenderer>(render_panel_);
+    video_ptr->AddRenderer(slot_->remote_video_renderer.get());
+    Log("[%s] attached video sink renderer", slot_->tag());
+}
+
+}  // namespace
+
+class MainFrame : public wxFrame {
+public:
+    MainFrame()
+        : wxFrame(nullptr, wxID_ANY, "libwebrtc loopback demo (C++ API)",
+                  wxDefaultPosition, wxSize(960, 600)),
+          offerer_("offerer"),
+          answerer_("answerer") {
+        // wxImage codec table is empty by default — register at least JPEG/PNG
+        // handlers so wxBitmap conversions used by VideoRenderPanel work cleanly.
+        wxInitAllImageHandlers();
+
+        auto* panel = new wxPanel(this);
+        auto* root = new wxBoxSizer(wxVERTICAL);
+
+        auto* buttons = new wxBoxSizer(wxHORIZONTAL);
+        start_btn_ = new wxButton(panel, wxID_ANY, "Start loopback");
+        stop_btn_ = new wxButton(panel, wxID_ANY, "Stop");
+        stop_btn_->Disable();
+        buttons->Add(start_btn_, 0, wxALL, 5);
+        buttons->Add(stop_btn_, 0, wxALL, 5);
+
+        status_ = new wxStaticText(panel, wxID_ANY, "Idle.");
+
+        auto* split = new wxBoxSizer(wxHORIZONTAL);
+        video_panel_ = new VideoRenderPanel(panel);
+        log_ = new wxTextCtrl(panel, wxID_ANY, wxEmptyString,
+                              wxDefaultPosition, wxDefaultSize,
+                              wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+        split->Add(video_panel_, 1, wxEXPAND | wxALL, 5);
+        split->Add(log_, 1, wxEXPAND | wxALL, 5);
+
+        root->Add(buttons, 0, wxEXPAND);
+        root->Add(status_, 0, wxALL, 5);
+        root->Add(split, 1, wxEXPAND);
+        panel->SetSizerAndFit(root);
+
+        start_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStart, this);
+        stop_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStop, this);
+        Bind(wxEVT_CLOSE_WINDOW, &MainFrame::OnClose, this);
+
+        g_logger = new UiLogger(log_);
+    }
+
+    ~MainFrame() override {
+        TeardownLoopback();
+        delete g_logger;
+        g_logger = nullptr;
+    }
+
+private:
+    void OnStart(wxCommandEvent&) {
+        if (running_) return;
+        status_->SetLabel("Starting...");
+        Log("LibWebRTC::Initialize");
+        if (!libwebrtc::LibWebRTC::Initialize()) {
+            status_->SetLabel("LibWebRTC::Initialize failed");
+            return;
+        }
+
+        factory_ = libwebrtc::LibWebRTC::CreateRTCPeerConnectionFactory();
+        if (!factory_ || !factory_->Initialize()) {
+            status_->SetLabel("Factory init failed");
+            return;
+        }
+
+        offerer_.remote = &answerer_;
+        answerer_.remote = &offerer_;
+        offerer_.closed.store(false);
+        answerer_.closed.store(false);
+
+        libwebrtc::RTCConfiguration config{};
+        scoped_refptr<libwebrtc::RTCMediaConstraints> pc_constraints =
+            libwebrtc::RTCMediaConstraints::Create();
+
+        offerer_.pc = factory_->Create(config, pc_constraints);
+        answerer_.pc = factory_->Create(config, pc_constraints);
+        if (!offerer_.pc || !answerer_.pc) {
+            status_->SetLabel("Create RTCPeerConnection failed");
+            TeardownLoopback();
+            return;
+        }
+
+        offerer_.observer = std::make_unique<LoopbackObserver>(&offerer_);
+        // The answerer is the one receiving the video — give it the panel so
+        // its OnAddTrack can hook the renderer up for display.
+        answerer_.observer =
+            std::make_unique<LoopbackObserver>(&answerer_, video_panel_);
+        offerer_.pc->RegisterRTCPeerConnectionObserver(offerer_.observer.get());
+        answerer_.pc->RegisterRTCPeerConnectionObserver(
+            answerer_.observer.get());
+
+        scoped_refptr<libwebrtc::RTCAudioSource> audio_source =
+            factory_->CreateAudioSource("loopback-audio");
+        if (!audio_source) {
+            status_->SetLabel("CreateAudioSource failed");
+            TeardownLoopback();
+            return;
+        }
+        scoped_refptr<libwebrtc::RTCAudioTrack> audio_track =
+            factory_->CreateAudioTrack(audio_source, "loopback-track-0");
+        if (!audio_track) {
+            status_->SetLabel("CreateAudioTrack failed");
+            TeardownLoopback();
+            return;
+        }
+
+        std::vector<string> stream_ids;
+        stream_ids.push_back(string("loopback-stream"));
+        offerer_.pc->AddTrack(audio_track, stream_ids);
+
+        // Synthetic video track: a custom (no-device) capturer is created and
+        // the source is fed by a producer thread that emits a 640x480 frame
+        // cycling through red / green / blue / white / black, one full-screen
+        // colour per second.
+
+        scoped_refptr<libwebrtc::RTCMediaConstraints> video_constraints =
+            libwebrtc::RTCMediaConstraints::Create();
+        video_source_ = factory_->CreateCustomVideoSource("synthetic-video",
+                                                          video_constraints);
+        if (video_source_) {
+          local_video_track_ =
+              factory_->CreateVideoTrack(video_source_, "synthetic-video-0");
+        }
+        if (local_video_track_) {
+          offerer_.pc->AddTrack(local_video_track_, stream_ids);
+          Log("Pushing 640x480 synthetic frames at 30 fps");
+          pusher_running_.store(true);
+          scoped_refptr<libwebrtc::RTCVideoSource> src = video_source_;
+          pusher_thread_ =
+              std::thread([this, src] { PushSyntheticFrames(src); });
+        } else {
+          Log("CreateVideoTrack failed; continuing audio-only");
+        }
+
+        scoped_refptr<libwebrtc::RTCMediaConstraints> sdp_constraints =
+            libwebrtc::RTCMediaConstraints::Create();
+
+        // Kick off the negotiation: offerer creates the offer, the success
+        // callback feeds it into both sides and asks the answerer for an
+        // answer, which in turn is fed back into both sides.
+        offerer_.pc->CreateOffer(
+            [this, sdp_constraints](const string sdp, const string type) {
+                Log("[offerer] CreateOffer ok, len=%zu",
+                    std::strlen(sdp.c_string()));
+                offerer_.pc->SetLocalDescription(
+                    sdp, type, []() {}, OnSetSdpFailureForTag("offerer"));
+                answerer_.pc->SetRemoteDescription(
+                    sdp, type, []() {}, OnSetSdpFailureForTag("answerer"));
+                answerer_.pc->CreateAnswer(
+                    [this](const string sdp, const string type) {
+                        Log("[answerer] CreateAnswer ok, len=%zu",
+                            std::strlen(sdp.c_string()));
+                        answerer_.pc->SetLocalDescription(
+                            sdp, type, []() {},
+                            OnSetSdpFailureForTag("answerer"));
+                        offerer_.pc->SetRemoteDescription(
+                            sdp, type, []() {},
+                            OnSetSdpFailureForTag("offerer"));
+                    },
+                    OnSdpCreateFailureForTag("answerer"), sdp_constraints);
+            },
+            OnSdpCreateFailureForTag("offerer"), sdp_constraints);
+
+        running_ = true;
+        start_btn_->Disable();
+        stop_btn_->Enable();
+        status_->SetLabel("Loopback running. See log below.");
+    }
+
+    void OnStop(wxCommandEvent&) {
+        TeardownLoopback();
+        status_->SetLabel("Stopped.");
+        start_btn_->Enable();
+        stop_btn_->Disable();
+    }
+
+    void OnClose(wxCloseEvent& event) {
+        TeardownLoopback();
+        event.Skip();
+    }
+
+    void TeardownLoopback() {
+        offerer_.closed.store(true);
+        answerer_.closed.store(true);
+
+        // Stop the synthetic frame producer before anything else so a frame
+        // that's mid-OnCapturedFrame finishes against still-live state.
+        if (pusher_running_.exchange(false)) {
+            if (pusher_thread_.joinable()) pusher_thread_.join();
+        }
+
+        // Detach renderers so we drop the dangling pointer before the unique_ptr
+        // resets.
+        for (PeerSlot* slot : {&offerer_, &answerer_}) {
+            if (slot->remote_video_track && slot->remote_video_renderer) {
+                slot->remote_video_track->RemoveRenderer(
+                    slot->remote_video_renderer.get());
+            }
+            slot->remote_video_track = nullptr;
+            slot->remote_video_renderer.reset();
+        }
+
+        local_video_track_ = nullptr;
+        video_source_ = nullptr;
+
+        if (offerer_.pc) {
+            offerer_.pc->Close();
+            if (factory_) factory_->Delete(offerer_.pc);
+            offerer_.pc = nullptr;
+        }
+        if (answerer_.pc) {
+            answerer_.pc->Close();
+            if (factory_) factory_->Delete(answerer_.pc);
+            answerer_.pc = nullptr;
+        }
+        offerer_.observer.reset();
+        answerer_.observer.reset();
+
+        if (factory_) {
+            factory_->Terminate();
+            factory_ = nullptr;
+            libwebrtc::LibWebRTC::Terminate();
+        }
+        running_ = false;
+    }
+
+    static libwebrtc::OnSdpCreateFailure OnSdpCreateFailureForTag(
+        const char* tag) {
+        return [tag](const char* error) {
+            Log("[%s] SDP create failure: %s", tag, error ? error : "(null)");
+        };
+    }
+
+    static libwebrtc::OnSetSdpFailure OnSetSdpFailureForTag(const char* tag) {
+        return [tag](const char* error) {
+            Log("[%s] SetDescription failure: %s", tag,
+                error ? error : "(null)");
+        };
+    }
+
+    wxButton* start_btn_;
+    wxButton* stop_btn_;
+    wxStaticText* status_;
+    wxTextCtrl* log_;
+    VideoRenderPanel* video_panel_ = nullptr;
+
+    // Generates a 640x480 I420 frame containing 8 vertical SMPTE-style colour
+    // bars that scroll horizontally a few pixels per frame, and pushes it
+    // through RTCVideoSource::OnCapturedFrame at ~30 fps. Holds a strong ref
+    // to the source so the source can't be destroyed mid-call.
+    void PushSyntheticFrames(scoped_refptr<libwebrtc::RTCVideoSource> source) {
+        constexpr int kWidth = 640;
+        constexpr int kHeight = 480;
+        constexpr int kYSize = kWidth * kHeight;
+        constexpr int kUVStride = kWidth / 2;
+        constexpr int kUVHeight = kHeight / 2;
+        constexpr int kUVSize = kUVStride * kUVHeight;
+        constexpr int kFrameBytes = kYSize + 2 * kUVSize;  // I420 packed
+        constexpr int kFps = 30;
+        constexpr auto kFrameInterval =
+            std::chrono::microseconds(1'000'000 / kFps);
+
+        constexpr int kBars = 8;
+        constexpr int kBarWidth = kWidth / kBars;          // 80 px
+        constexpr int kScrollPxPerFrame = 4;               // ~ 120 px/sec
+
+        // BT.601 limited-range YUV for the eight reference colour bars,
+        // ordered the way SMPTE 75 % bars are typically drawn left to right.
+        struct YUV { uint8_t y, u, v; };
+        constexpr YUV palette[kBars] = {
+            {235, 128, 128}, // white
+            {210,  16, 146}, // yellow
+            {170, 166,  16}, // cyan
+            {145,  54,  34}, // green
+            {106, 202, 222}, // magenta
+            { 81,  90, 240}, // red
+            { 41, 240, 110}, // blue
+            { 16, 128, 128}, // black
+        };
+
+        std::vector<uint8_t> buffer(kFrameBytes);
+        uint8_t* y_plane = buffer.data();
+        uint8_t* u_plane = y_plane + kYSize;
+        uint8_t* v_plane = u_plane + kUVSize;
+
+        // The bar pattern is constant per row, so we build one row of Y, U,
+        // V samples and memcpy it to every scanline. Far cheaper than a 2D
+        // nested loop, and keeps the cost trivial at 640x480 / 30fps.
+        std::vector<uint8_t> y_row(kWidth);
+        std::vector<uint8_t> u_row(kUVStride);
+        std::vector<uint8_t> v_row(kUVStride);
+
+        int frame_idx = 0;
+        auto next_tick = std::chrono::steady_clock::now();
+
+        while (pusher_running_.load()) {
+            int scroll = (frame_idx * kScrollPxPerFrame) % kWidth;
+
+            // Build one Y row: each column picks its bar from the scrolled
+            // pattern.
+            for (int x = 0; x < kWidth; ++x) {
+                int bar = ((x + scroll) % kWidth) / kBarWidth;
+                y_row[x] = palette[bar].y;
+            }
+            // Build one U/V row at half horizontal resolution. Sample at
+            // x*2 to match the I420 chroma siting.
+            for (int x = 0; x < kUVStride; ++x) {
+                int bar = ((x * 2 + scroll) % kWidth) / kBarWidth;
+                u_row[x] = palette[bar].u;
+                v_row[x] = palette[bar].v;
+            }
+            // Replicate rows down each plane.
+            for (int y = 0; y < kHeight; ++y) {
+                std::memcpy(y_plane + y * kWidth, y_row.data(), kWidth);
+            }
+            for (int y = 0; y < kUVHeight; ++y) {
+                std::memcpy(u_plane + y * kUVStride, u_row.data(), kUVStride);
+                std::memcpy(v_plane + y * kUVStride, v_row.data(), kUVStride);
+            }
+
+            scoped_refptr<libwebrtc::RTCVideoFrame> frame =
+                libwebrtc::RTCVideoFrame::Create(kWidth, kHeight,
+                                                 buffer.data(), kFrameBytes);
+            if (frame) source->OnCapturedFrame(frame);
+
+            if (frame_idx % (kFps * 2) == 0) {
+                Log("[pusher] color bars frame #%d (scroll=%d)",
+                    frame_idx, scroll);
+            }
+            ++frame_idx;
+            next_tick += kFrameInterval;
+            std::this_thread::sleep_until(next_tick);
+        }
+    }
+
+    scoped_refptr<libwebrtc::RTCPeerConnectionFactory> factory_;
+    PeerSlot offerer_;
+    PeerSlot answerer_;
+
+    scoped_refptr<libwebrtc::RTCVideoSource>   video_source_;
+    scoped_refptr<libwebrtc::RTCVideoTrack>    local_video_track_;
+
+    std::thread pusher_thread_;
+    std::atomic<bool> pusher_running_{false};
+
+    bool running_ = false;
+};
+
+class LoopbackApp : public wxApp {
+public:
+    bool OnInit() override {
+        auto* frame = new MainFrame();
+        frame->Show();
+        return true;
+    }
+};
+
+wxIMPLEMENT_APP(LoopbackApp);

--- a/examples/wx_loop_back_demo/main.cc
+++ b/examples/wx_loop_back_demo/main.cc
@@ -422,6 +422,7 @@ class MainFrame : public wxFrame {
     factory_ = libwebrtc::LibWebRTC::CreateRTCPeerConnectionFactory();
     if (!factory_ || !factory_->Initialize()) {
       status_->SetLabel("Factory init failed");
+      TeardownLoopback();
       return;
     }
 

--- a/examples/wx_loop_back_demo/main.cc
+++ b/examples/wx_loop_back_demo/main.cc
@@ -2,9 +2,9 @@
 // C++ API: two in-process RTCPeerConnections negotiate over a fake signaling
 // channel and stream a single audio track from one to the other.
 
-#include <wx/wx.h>
-#include <wx/textctrl.h>
 #include <wx/sizer.h>
+#include <wx/textctrl.h>
+#include <wx/wx.h>
 
 #include <algorithm>
 #include <atomic>
@@ -16,23 +16,23 @@
 #include <vector>
 
 #include "libwebrtc.h"
-#include "rtc_peerconnection.h"
-#include "rtc_peerconnection_factory.h"
-#include "rtc_mediaconstraints.h"
-#include "rtc_ice_candidate.h"
 #include "rtc_audio_source.h"
 #include "rtc_audio_track.h"
+#include "rtc_data_channel.h"
+#include "rtc_ice_candidate.h"
+#include "rtc_media_stream.h"
+#include "rtc_media_track.h"
+#include "rtc_mediaconstraints.h"
+#include "rtc_peerconnection.h"
+#include "rtc_peerconnection_factory.h"
+#include "rtc_rtp_receiver.h"
 #include "rtc_rtp_sender.h"
 #include "rtc_rtp_transceiver.h"
-#include "rtc_media_stream.h"
-#include "rtc_data_channel.h"
-#include "rtc_rtp_receiver.h"
 #include "rtc_video_device.h"
-#include "rtc_video_source.h"
-#include "rtc_video_track.h"
 #include "rtc_video_frame.h"
 #include "rtc_video_renderer.h"
-#include "rtc_media_track.h"
+#include "rtc_video_source.h"
+#include "rtc_video_track.h"
 
 using libwebrtc::scoped_refptr;
 using libwebrtc::string;
@@ -42,93 +42,119 @@ namespace {
 // Marshals log messages to the wxTextCtrl on the UI thread regardless of
 // which libwebrtc thread emits them.
 class UiLogger {
-public:
-    explicit UiLogger(wxTextCtrl* sink) : sink_(sink) {}
+ public:
+  explicit UiLogger(wxTextCtrl* sink) : sink_(sink) {}
 
-    void Log(const wxString& message) {
-        wxTextCtrl* sink = sink_;
-        if (wxIsMainThread()) {
-            sink->AppendText(message + "\n");
-        } else {
-            wxString copy = message;
-            sink->GetEventHandler()->CallAfter([sink, copy] {
-                sink->AppendText(copy + "\n");
-            });
-        }
+  void Log(const wxString& message) {
+    wxTextCtrl* sink = sink_;
+    if (wxIsMainThread()) {
+      sink->AppendText(message + "\n");
+    } else {
+      wxString copy = message;
+      sink->GetEventHandler()->CallAfter(
+          [sink, copy] { sink->AppendText(copy + "\n"); });
     }
+  }
 
-private:
-    wxTextCtrl* sink_;
+ private:
+  wxTextCtrl* sink_;
 };
 
 UiLogger* g_logger = nullptr;
 
 void Log(const char* fmt, ...) {
-    if (!g_logger) return;
-    char buf[1024];
-    va_list ap;
-    va_start(ap, fmt);
-    std::vsnprintf(buf, sizeof(buf), fmt, ap);
-    va_end(ap);
-    g_logger->Log(wxString::FromUTF8(buf));
+  if (!g_logger) return;
+  char buf[1024];
+  va_list ap;
+  va_start(ap, fmt);
+  std::vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+  g_logger->Log(wxString::FromUTF8(buf));
 }
 
 // Enum -> human-readable name. Keeps log lines greppable.
 const char* ToString(libwebrtc::RTCSignalingState s) {
-    switch (s) {
-        case libwebrtc::RTCSignalingStateStable:             return "Stable";
-        case libwebrtc::RTCSignalingStateHaveLocalOffer:     return "HaveLocalOffer";
-        case libwebrtc::RTCSignalingStateHaveRemoteOffer:    return "HaveRemoteOffer";
-        case libwebrtc::RTCSignalingStateHaveLocalPrAnswer:  return "HaveLocalPrAnswer";
-        case libwebrtc::RTCSignalingStateHaveRemotePrAnswer: return "HaveRemotePrAnswer";
-        case libwebrtc::RTCSignalingStateClosed:             return "Closed";
-    }
-    return "?";
+  switch (s) {
+    case libwebrtc::RTCSignalingStateStable:
+      return "Stable";
+    case libwebrtc::RTCSignalingStateHaveLocalOffer:
+      return "HaveLocalOffer";
+    case libwebrtc::RTCSignalingStateHaveRemoteOffer:
+      return "HaveRemoteOffer";
+    case libwebrtc::RTCSignalingStateHaveLocalPrAnswer:
+      return "HaveLocalPrAnswer";
+    case libwebrtc::RTCSignalingStateHaveRemotePrAnswer:
+      return "HaveRemotePrAnswer";
+    case libwebrtc::RTCSignalingStateClosed:
+      return "Closed";
+  }
+  return "?";
 }
 
 const char* ToString(libwebrtc::RTCPeerConnectionState s) {
-    switch (s) {
-        case libwebrtc::RTCPeerConnectionStateNew:          return "New";
-        case libwebrtc::RTCPeerConnectionStateConnecting:   return "Connecting";
-        case libwebrtc::RTCPeerConnectionStateConnected:    return "Connected";
-        case libwebrtc::RTCPeerConnectionStateDisconnected: return "Disconnected";
-        case libwebrtc::RTCPeerConnectionStateFailed:       return "Failed";
-        case libwebrtc::RTCPeerConnectionStateClosed:       return "Closed";
-    }
-    return "?";
+  switch (s) {
+    case libwebrtc::RTCPeerConnectionStateNew:
+      return "New";
+    case libwebrtc::RTCPeerConnectionStateConnecting:
+      return "Connecting";
+    case libwebrtc::RTCPeerConnectionStateConnected:
+      return "Connected";
+    case libwebrtc::RTCPeerConnectionStateDisconnected:
+      return "Disconnected";
+    case libwebrtc::RTCPeerConnectionStateFailed:
+      return "Failed";
+    case libwebrtc::RTCPeerConnectionStateClosed:
+      return "Closed";
+  }
+  return "?";
 }
 
 const char* ToString(libwebrtc::RTCIceGatheringState s) {
-    switch (s) {
-        case libwebrtc::RTCIceGatheringStateNew:       return "New";
-        case libwebrtc::RTCIceGatheringStateGathering: return "Gathering";
-        case libwebrtc::RTCIceGatheringStateComplete:  return "Complete";
-    }
-    return "?";
+  switch (s) {
+    case libwebrtc::RTCIceGatheringStateNew:
+      return "New";
+    case libwebrtc::RTCIceGatheringStateGathering:
+      return "Gathering";
+    case libwebrtc::RTCIceGatheringStateComplete:
+      return "Complete";
+  }
+  return "?";
 }
 
 const char* ToString(libwebrtc::RTCIceConnectionState s) {
-    switch (s) {
-        case libwebrtc::RTCIceConnectionStateNew:          return "New";
-        case libwebrtc::RTCIceConnectionStateChecking:     return "Checking";
-        case libwebrtc::RTCIceConnectionStateCompleted:    return "Completed";
-        case libwebrtc::RTCIceConnectionStateConnected:    return "Connected";
-        case libwebrtc::RTCIceConnectionStateFailed:       return "Failed";
-        case libwebrtc::RTCIceConnectionStateDisconnected: return "Disconnected";
-        case libwebrtc::RTCIceConnectionStateClosed:       return "Closed";
-        case libwebrtc::RTCIceConnectionStateMax:          return "Max";
-    }
-    return "?";
+  switch (s) {
+    case libwebrtc::RTCIceConnectionStateNew:
+      return "New";
+    case libwebrtc::RTCIceConnectionStateChecking:
+      return "Checking";
+    case libwebrtc::RTCIceConnectionStateCompleted:
+      return "Completed";
+    case libwebrtc::RTCIceConnectionStateConnected:
+      return "Connected";
+    case libwebrtc::RTCIceConnectionStateFailed:
+      return "Failed";
+    case libwebrtc::RTCIceConnectionStateDisconnected:
+      return "Disconnected";
+    case libwebrtc::RTCIceConnectionStateClosed:
+      return "Closed";
+    case libwebrtc::RTCIceConnectionStateMax:
+      return "Max";
+  }
+  return "?";
 }
 
 const char* ToString(libwebrtc::RTCMediaType t) {
-    switch (t) {
-        case libwebrtc::RTCMediaType::AUDIO:       return "AUDIO";
-        case libwebrtc::RTCMediaType::VIDEO:       return "VIDEO";
-        case libwebrtc::RTCMediaType::DATA:        return "DATA";
-        case libwebrtc::RTCMediaType::UNSUPPORTED: return "UNSUPPORTED";
-    }
-    return "?";
+  switch (t) {
+    case libwebrtc::RTCMediaType::AUDIO:
+      return "AUDIO";
+    case libwebrtc::RTCMediaType::VIDEO:
+      return "VIDEO";
+    case libwebrtc::RTCMediaType::DATA:
+      return "DATA";
+    case libwebrtc::RTCMediaType::UNSUPPORTED:
+      return "UNSUPPORTED";
+  }
+  return "?";
 }
 
 class PeerSlot;
@@ -138,163 +164,147 @@ class PeerSlot;
 // thread via UpdateFrame; the actual rasterisation happens in OnPaint on the
 // UI thread.
 class VideoRenderPanel : public wxPanel {
-public:
-    VideoRenderPanel(wxWindow* parent)
-        : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240)) {
-        SetBackgroundStyle(wxBG_STYLE_PAINT);
-        SetBackgroundColour(*wxBLACK);
-        Bind(wxEVT_PAINT, &VideoRenderPanel::OnPaint, this);
-    }
+ public:
+  VideoRenderPanel(wxWindow* parent)
+      : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(320, 240)) {
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    SetBackgroundColour(*wxBLACK);
+    Bind(wxEVT_PAINT, &VideoRenderPanel::OnPaint, this);
+  }
 
-    // Thread-safe: takes the wxImage by value, marshals to UI thread.
-    void UpdateFrame(wxImage image) {
-        if (wxIsMainThread()) {
-            latest_image_ = std::move(image);
-            Refresh(false);
-            return;
-        }
-        wxImage captured = std::move(image);
-        GetEventHandler()->CallAfter(
-            [this, captured = std::move(captured)]() mutable {
-                latest_image_ = std::move(captured);
-                Refresh(false);
-            });
+  // Thread-safe: takes the wxImage by value, marshals to UI thread.
+  void UpdateFrame(wxImage image) {
+    if (wxIsMainThread()) {
+      latest_image_ = std::move(image);
+      Refresh(false);
+      return;
     }
+    wxImage captured = std::move(image);
+    GetEventHandler()->CallAfter(
+        [this, captured = std::move(captured)]() mutable {
+          latest_image_ = std::move(captured);
+          Refresh(false);
+        });
+  }
 
-private:
-    void OnPaint(wxPaintEvent&) {
-        wxPaintDC dc(this);
-        wxSize sz = GetClientSize();
-        if (sz.x <= 0 || sz.y <= 0) return;
-        if (!latest_image_.IsOk()) {
-            dc.SetBackground(*wxBLACK_BRUSH);
-            dc.Clear();
-            return;
-        }
-        wxImage scaled = (latest_image_.GetWidth() != sz.x ||
-                          latest_image_.GetHeight() != sz.y)
-                             ? latest_image_.Scale(sz.x, sz.y,
-                                                   wxIMAGE_QUALITY_NEAREST)
-                             : latest_image_;
-        dc.DrawBitmap(wxBitmap(scaled), 0, 0);
+ private:
+  void OnPaint(wxPaintEvent&) {
+    wxPaintDC dc(this);
+    wxSize sz = GetClientSize();
+    if (sz.x <= 0 || sz.y <= 0) return;
+    if (!latest_image_.IsOk()) {
+      dc.SetBackground(*wxBLACK_BRUSH);
+      dc.Clear();
+      return;
     }
+    wxImage scaled =
+        (latest_image_.GetWidth() != sz.x || latest_image_.GetHeight() != sz.y)
+            ? latest_image_.Scale(sz.x, sz.y, wxIMAGE_QUALITY_NEAREST)
+            : latest_image_;
+    dc.DrawBitmap(wxBitmap(scaled), 0, 0);
+  }
 
-    wxImage latest_image_;  // touched only on UI thread
+  wxImage latest_image_;  // touched only on UI thread
 };
 
 // RTCVideoRenderer adapter that converts each decoded I420 frame into a
 // wxImage and hands it to a VideoRenderPanel for display. Also keeps a
 // running count for diagnostic logging.
-class VideoSinkRenderer
-    : public libwebrtc::RTCVideoRenderer<scoped_refptr<libwebrtc::RTCVideoFrame>> {
-public:
-    explicit VideoSinkRenderer(VideoRenderPanel* panel) : panel_(panel) {}
+class VideoSinkRenderer : public libwebrtc::RTCVideoRenderer<
+                              scoped_refptr<libwebrtc::RTCVideoFrame>> {
+ public:
+  explicit VideoSinkRenderer(VideoRenderPanel* panel) : panel_(panel) {}
 
-    void OnFrame(scoped_refptr<libwebrtc::RTCVideoFrame> frame) override {
-        if (!frame || !panel_) return;
-        const int w = frame->width();
-        const int h = frame->height();
-        if (w <= 0 || h <= 0) return;
+  void OnFrame(scoped_refptr<libwebrtc::RTCVideoFrame> frame) override {
+    if (!frame || !panel_) return;
+    const int w = frame->width();
+    const int h = frame->height();
+    if (w <= 0 || h <= 0) return;
 
-        // libyuv::I420ToABGR places bytes in memory as R, G, B, A — exactly
-        // the order wxImage's RGB buffer wants for the first three.
-        std::vector<uint8_t> abgr(static_cast<size_t>(w) * h * 4);
-        frame->ConvertToARGB(libwebrtc::RTCVideoFrame::Type::kABGR,
-                             abgr.data(), w * 4, w, h);
+    // libyuv::I420ToABGR places bytes in memory as R, G, B, A — exactly
+    // the order wxImage's RGB buffer wants for the first three.
+    std::vector<uint8_t> abgr(static_cast<size_t>(w) * h * 4);
+    frame->ConvertToARGB(libwebrtc::RTCVideoFrame::Type::kABGR, abgr.data(),
+                         w * 4, w, h);
 
-        // wxImage requires its data pointer to be malloc()'d so it can free()
-        // on destruction. Strip the alpha channel as we copy.
-        unsigned char* rgb =
-            static_cast<unsigned char*>(std::malloc(static_cast<size_t>(w) * h * 3));
-        if (!rgb) return;
-        for (int i = 0; i < w * h; ++i) {
-            rgb[i * 3 + 0] = abgr[i * 4 + 0];
-            rgb[i * 3 + 1] = abgr[i * 4 + 1];
-            rgb[i * 3 + 2] = abgr[i * 4 + 2];
-        }
-        wxImage image(w, h, rgb);  // takes ownership
-
-        size_t n = ++count_;
-        if (n == 1 || n % 30 == 0) {
-            Log("[remote video] frame #%zu: %dx%d", n, w, h);
-        }
-        panel_->UpdateFrame(std::move(image));
+    // wxImage requires its data pointer to be malloc()'d so it can free()
+    // on destruction. Strip the alpha channel as we copy.
+    unsigned char* rgb = static_cast<unsigned char*>(
+        std::malloc(static_cast<size_t>(w) * h * 3));
+    if (!rgb) return;
+    for (int i = 0; i < w * h; ++i) {
+      rgb[i * 3 + 0] = abgr[i * 4 + 0];
+      rgb[i * 3 + 1] = abgr[i * 4 + 1];
+      rgb[i * 3 + 2] = abgr[i * 4 + 2];
     }
+    wxImage image(w, h, rgb);  // takes ownership
 
-private:
-    VideoRenderPanel* panel_;
-    std::atomic<size_t> count_{0};
+    size_t n = ++count_;
+    if (n == 1 || n % 30 == 0) {
+      Log("[remote video] frame #%zu: %dx%d", n, w, h);
+    }
+    panel_->UpdateFrame(std::move(image));
+  }
+
+ private:
+  VideoRenderPanel* panel_;
+  std::atomic<size_t> count_{0};
 };
 
-// Observer attached to one peer; forwards ICE candidates to the loopback peer
-// and reports state changes to the UI log.
-class LoopbackObserver : public libwebrtc::RTCPeerConnectionObserver {
-public:
-    LoopbackObserver(PeerSlot* slot, VideoRenderPanel* render_panel = nullptr)
-        : slot_(slot), render_panel_(render_panel) {}
-
-    void OnSignalingState(libwebrtc::RTCSignalingState state) override;
-    void OnPeerConnectionState(libwebrtc::RTCPeerConnectionState state) override;
-    void OnIceGatheringState(libwebrtc::RTCIceGatheringState state) override;
-    void OnIceConnectionState(libwebrtc::RTCIceConnectionState state) override;
-    void OnIceCandidate(scoped_refptr<libwebrtc::RTCIceCandidate> candidate) override;
-    void OnAddStream(scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
-    void OnRemoveStream(scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
-    void OnDataChannel(scoped_refptr<libwebrtc::RTCDataChannel> /*dc*/) override {}
-    void OnRenegotiationNeeded() override {}
-    void OnTrack(scoped_refptr<libwebrtc::RTCRtpTransceiver> /*t*/) override {}
-    void OnAddTrack(libwebrtc::vector<scoped_refptr<libwebrtc::RTCMediaStream>> /*streams*/,
-                    scoped_refptr<libwebrtc::RTCRtpReceiver> receiver) override;
-    void OnRemoveTrack(scoped_refptr<libwebrtc::RTCRtpReceiver> /*receiver*/) override {}
-
-private:
-    PeerSlot* slot_;
-    VideoRenderPanel* render_panel_;
-};
+class LoopbackObserver;  // defined below; PeerSlot only needs the type
+                         // for unique_ptr storage.
 
 // Holds the state of a single peer in the loopback pair.
 class PeerSlot {
-public:
-    PeerSlot(const char* tag) : tag_(tag) {}
+ public:
+  PeerSlot(const char* tag) : tag_(tag) {}
+  // Defined out-of-line below — needed because `observer` is a
+  // unique_ptr<LoopbackObserver> and LoopbackObserver is incomplete here.
+  ~PeerSlot() = default;
 
-    const char* tag() const { return tag_; }
+  const char* tag() const { return tag_; }
 
-    scoped_refptr<libwebrtc::RTCPeerConnection> pc;
-    PeerSlot* remote = nullptr;
-    std::atomic<bool> closed{false};
-    std::unique_ptr<LoopbackObserver> observer;
+  scoped_refptr<libwebrtc::RTCPeerConnection> pc;
+  PeerSlot* remote = nullptr;
+  std::atomic<bool> closed{false};
+  std::unique_ptr<LoopbackObserver> observer;
 
-    // Filled in when the remote side receives a video track. The track ref
-    // keeps the underlying object alive for as long as we have a renderer
-    // attached to it.
-    scoped_refptr<libwebrtc::RTCVideoTrack> remote_video_track;
-    std::unique_ptr<VideoSinkRenderer> remote_video_renderer;
+  // Filled in when the remote side receives a video track. The track ref
+  // keeps the underlying object alive for as long as we have a renderer
+  // attached to it.
+  scoped_refptr<libwebrtc::RTCVideoTrack> remote_video_track;
+  std::unique_ptr<VideoSinkRenderer> remote_video_renderer;
 
-private:
-    const char* tag_;
+ private:
+  const char* tag_;
 };
 
-void LoopbackObserver::OnSignalingState(libwebrtc::RTCSignalingState state) {
+// Observer attached to one peer; forwards ICE candidates to the loopback peer
+// and reports state changes to the UI log. Methods are defined inline because
+// PeerSlot is now a complete type at this point.
+class LoopbackObserver : public libwebrtc::RTCPeerConnectionObserver {
+ public:
+  LoopbackObserver(PeerSlot* slot, VideoRenderPanel* render_panel = nullptr)
+      : slot_(slot), render_panel_(render_panel) {}
+
+  void OnSignalingState(libwebrtc::RTCSignalingState state) override {
     Log("[%s] signaling state -> %s", slot_->tag(), ToString(state));
-}
+  }
 
-void LoopbackObserver::OnPeerConnectionState(
-    libwebrtc::RTCPeerConnectionState state) {
+  void OnPeerConnectionState(libwebrtc::RTCPeerConnectionState state) override {
     Log("[%s] pc state -> %s", slot_->tag(), ToString(state));
-}
+  }
 
-void LoopbackObserver::OnIceGatheringState(
-    libwebrtc::RTCIceGatheringState state) {
+  void OnIceGatheringState(libwebrtc::RTCIceGatheringState state) override {
     Log("[%s] ice gathering -> %s", slot_->tag(), ToString(state));
-}
+  }
 
-void LoopbackObserver::OnIceConnectionState(
-    libwebrtc::RTCIceConnectionState state) {
+  void OnIceConnectionState(libwebrtc::RTCIceConnectionState state) override {
     Log("[%s] ice connection -> %s", slot_->tag(), ToString(state));
-}
+  }
 
-void LoopbackObserver::OnIceCandidate(
-    scoped_refptr<libwebrtc::RTCIceCandidate> candidate) {
+  void OnIceCandidate(
+      scoped_refptr<libwebrtc::RTCIceCandidate> candidate) override {
     if (!candidate) return;
     PeerSlot* remote = slot_->remote;
     if (!remote || remote->closed.load() || !remote->pc) return;
@@ -303,14 +313,22 @@ void LoopbackObserver::OnIceCandidate(
         remote->tag(), candidate->sdp_mid().c_string(),
         candidate->sdp_mline_index());
 
-    remote->pc->AddCandidate(candidate->sdp_mid(),
-                             candidate->sdp_mline_index(),
+    remote->pc->AddCandidate(candidate->sdp_mid(), candidate->sdp_mline_index(),
                              candidate->candidate());
-}
+  }
 
-void LoopbackObserver::OnAddTrack(
-    libwebrtc::vector<scoped_refptr<libwebrtc::RTCMediaStream>> /*streams*/,
-    scoped_refptr<libwebrtc::RTCRtpReceiver> receiver) {
+  void OnAddStream(
+      scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
+  void OnRemoveStream(
+      scoped_refptr<libwebrtc::RTCMediaStream> /*stream*/) override {}
+  void OnDataChannel(scoped_refptr<libwebrtc::RTCDataChannel> /*dc*/) override {
+  }
+  void OnRenegotiationNeeded() override {}
+  void OnTrack(scoped_refptr<libwebrtc::RTCRtpTransceiver> /*t*/) override {}
+
+  void OnAddTrack(
+      libwebrtc::vector<scoped_refptr<libwebrtc::RTCMediaStream>> /*streams*/,
+      scoped_refptr<libwebrtc::RTCRtpReceiver> receiver) override {
     if (!receiver) return;
     Log("[%s] OnAddTrack (kind=%s)", slot_->tag(),
         ToString(receiver->media_type()));
@@ -321,8 +339,8 @@ void LoopbackObserver::OnAddTrack(
     if (!media) return;
 
     // Down-cast: when media_type is VIDEO the underlying track is a
-    // RTCVideoTrack, which is the only subclass of RTCMediaTrack that exposes
-    // AddRenderer/RemoveRenderer.
+    // RTCVideoTrack, which is the only subclass of RTCMediaTrack that
+    // exposes AddRenderer/RemoveRenderer.
     auto* video_ptr = static_cast<libwebrtc::RTCVideoTrack*>(media.get());
     slot_->remote_video_track =
         scoped_refptr<libwebrtc::RTCVideoTrack>(video_ptr);
@@ -330,365 +348,367 @@ void LoopbackObserver::OnAddTrack(
         std::make_unique<VideoSinkRenderer>(render_panel_);
     video_ptr->AddRenderer(slot_->remote_video_renderer.get());
     Log("[%s] attached video sink renderer", slot_->tag());
-}
+  }
+
+  void OnRemoveTrack(
+      scoped_refptr<libwebrtc::RTCRtpReceiver> /*receiver*/) override {}
+
+ private:
+  PeerSlot* slot_;
+  VideoRenderPanel* render_panel_;
+};
 
 }  // namespace
 
 class MainFrame : public wxFrame {
-public:
-    MainFrame()
-        : wxFrame(nullptr, wxID_ANY, "libwebrtc loopback demo (C++ API)",
-                  wxDefaultPosition, wxSize(960, 600)),
-          offerer_("offerer"),
-          answerer_("answerer") {
-        // wxImage codec table is empty by default — register at least JPEG/PNG
-        // handlers so wxBitmap conversions used by VideoRenderPanel work cleanly.
-        wxInitAllImageHandlers();
+ public:
+  MainFrame()
+      : wxFrame(nullptr, wxID_ANY, "libwebrtc loopback demo (C++ API)",
+                wxDefaultPosition, wxSize(960, 600)),
+        offerer_("offerer"),
+        answerer_("answerer") {
+    // wxImage codec table is empty by default — register at least JPEG/PNG
+    // handlers so wxBitmap conversions used by VideoRenderPanel work cleanly.
+    wxInitAllImageHandlers();
 
-        auto* panel = new wxPanel(this);
-        auto* root = new wxBoxSizer(wxVERTICAL);
+    auto* panel = new wxPanel(this);
+    auto* root = new wxBoxSizer(wxVERTICAL);
 
-        auto* buttons = new wxBoxSizer(wxHORIZONTAL);
-        start_btn_ = new wxButton(panel, wxID_ANY, "Start loopback");
-        stop_btn_ = new wxButton(panel, wxID_ANY, "Stop");
-        stop_btn_->Disable();
-        buttons->Add(start_btn_, 0, wxALL, 5);
-        buttons->Add(stop_btn_, 0, wxALL, 5);
+    auto* buttons = new wxBoxSizer(wxHORIZONTAL);
+    start_btn_ = new wxButton(panel, wxID_ANY, "Start loopback");
+    stop_btn_ = new wxButton(panel, wxID_ANY, "Stop");
+    stop_btn_->Disable();
+    buttons->Add(start_btn_, 0, wxALL, 5);
+    buttons->Add(stop_btn_, 0, wxALL, 5);
 
-        status_ = new wxStaticText(panel, wxID_ANY, "Idle.");
+    status_ = new wxStaticText(panel, wxID_ANY, "Idle.");
 
-        auto* split = new wxBoxSizer(wxHORIZONTAL);
-        video_panel_ = new VideoRenderPanel(panel);
-        log_ = new wxTextCtrl(panel, wxID_ANY, wxEmptyString,
-                              wxDefaultPosition, wxDefaultSize,
-                              wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
-        split->Add(video_panel_, 1, wxEXPAND | wxALL, 5);
-        split->Add(log_, 1, wxEXPAND | wxALL, 5);
+    auto* split = new wxBoxSizer(wxHORIZONTAL);
+    video_panel_ = new VideoRenderPanel(panel);
+    log_ = new wxTextCtrl(panel, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                          wxDefaultSize,
+                          wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+    split->Add(video_panel_, 1, wxEXPAND | wxALL, 5);
+    split->Add(log_, 1, wxEXPAND | wxALL, 5);
 
-        root->Add(buttons, 0, wxEXPAND);
-        root->Add(status_, 0, wxALL, 5);
-        root->Add(split, 1, wxEXPAND);
-        panel->SetSizerAndFit(root);
+    root->Add(buttons, 0, wxEXPAND);
+    root->Add(status_, 0, wxALL, 5);
+    root->Add(split, 1, wxEXPAND);
+    panel->SetSizerAndFit(root);
 
-        start_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStart, this);
-        stop_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStop, this);
-        Bind(wxEVT_CLOSE_WINDOW, &MainFrame::OnClose, this);
+    start_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStart, this);
+    stop_btn_->Bind(wxEVT_BUTTON, &MainFrame::OnStop, this);
+    Bind(wxEVT_CLOSE_WINDOW, &MainFrame::OnClose, this);
 
-        g_logger = new UiLogger(log_);
+    g_logger = new UiLogger(log_);
+  }
+
+  ~MainFrame() override {
+    TeardownLoopback();
+    delete g_logger;
+    g_logger = nullptr;
+  }
+
+ private:
+  void OnStart(wxCommandEvent&) {
+    if (running_) return;
+    status_->SetLabel("Starting...");
+    Log("LibWebRTC::Initialize");
+    if (!libwebrtc::LibWebRTC::Initialize()) {
+      status_->SetLabel("LibWebRTC::Initialize failed");
+      return;
     }
 
-    ~MainFrame() override {
-        TeardownLoopback();
-        delete g_logger;
-        g_logger = nullptr;
+    factory_ = libwebrtc::LibWebRTC::CreateRTCPeerConnectionFactory();
+    if (!factory_ || !factory_->Initialize()) {
+      status_->SetLabel("Factory init failed");
+      return;
     }
 
-private:
-    void OnStart(wxCommandEvent&) {
-        if (running_) return;
-        status_->SetLabel("Starting...");
-        Log("LibWebRTC::Initialize");
-        if (!libwebrtc::LibWebRTC::Initialize()) {
-            status_->SetLabel("LibWebRTC::Initialize failed");
-            return;
-        }
+    offerer_.remote = &answerer_;
+    answerer_.remote = &offerer_;
+    offerer_.closed.store(false);
+    answerer_.closed.store(false);
 
-        factory_ = libwebrtc::LibWebRTC::CreateRTCPeerConnectionFactory();
-        if (!factory_ || !factory_->Initialize()) {
-            status_->SetLabel("Factory init failed");
-            return;
-        }
+    libwebrtc::RTCConfiguration config{};
+    scoped_refptr<libwebrtc::RTCMediaConstraints> pc_constraints =
+        libwebrtc::RTCMediaConstraints::Create();
 
-        offerer_.remote = &answerer_;
-        answerer_.remote = &offerer_;
-        offerer_.closed.store(false);
-        answerer_.closed.store(false);
+    offerer_.pc = factory_->Create(config, pc_constraints);
+    answerer_.pc = factory_->Create(config, pc_constraints);
+    if (!offerer_.pc || !answerer_.pc) {
+      status_->SetLabel("Create RTCPeerConnection failed");
+      TeardownLoopback();
+      return;
+    }
 
-        libwebrtc::RTCConfiguration config{};
-        scoped_refptr<libwebrtc::RTCMediaConstraints> pc_constraints =
-            libwebrtc::RTCMediaConstraints::Create();
+    offerer_.observer = std::make_unique<LoopbackObserver>(&offerer_);
+    // The answerer is the one receiving the video — give it the panel so
+    // its OnAddTrack can hook the renderer up for display.
+    answerer_.observer =
+        std::make_unique<LoopbackObserver>(&answerer_, video_panel_);
+    offerer_.pc->RegisterRTCPeerConnectionObserver(offerer_.observer.get());
+    answerer_.pc->RegisterRTCPeerConnectionObserver(answerer_.observer.get());
 
-        offerer_.pc = factory_->Create(config, pc_constraints);
-        answerer_.pc = factory_->Create(config, pc_constraints);
-        if (!offerer_.pc || !answerer_.pc) {
-            status_->SetLabel("Create RTCPeerConnection failed");
-            TeardownLoopback();
-            return;
-        }
+    scoped_refptr<libwebrtc::RTCAudioSource> audio_source =
+        factory_->CreateAudioSource("loopback-audio");
+    if (!audio_source) {
+      status_->SetLabel("CreateAudioSource failed");
+      TeardownLoopback();
+      return;
+    }
+    scoped_refptr<libwebrtc::RTCAudioTrack> audio_track =
+        factory_->CreateAudioTrack(audio_source, "loopback-track-0");
+    if (!audio_track) {
+      status_->SetLabel("CreateAudioTrack failed");
+      TeardownLoopback();
+      return;
+    }
 
-        offerer_.observer = std::make_unique<LoopbackObserver>(&offerer_);
-        // The answerer is the one receiving the video — give it the panel so
-        // its OnAddTrack can hook the renderer up for display.
-        answerer_.observer =
-            std::make_unique<LoopbackObserver>(&answerer_, video_panel_);
-        offerer_.pc->RegisterRTCPeerConnectionObserver(offerer_.observer.get());
-        answerer_.pc->RegisterRTCPeerConnectionObserver(
-            answerer_.observer.get());
+    std::vector<string> stream_ids;
+    stream_ids.push_back(string("loopback-stream"));
+    offerer_.pc->AddTrack(audio_track, stream_ids);
 
-        scoped_refptr<libwebrtc::RTCAudioSource> audio_source =
-            factory_->CreateAudioSource("loopback-audio");
-        if (!audio_source) {
-            status_->SetLabel("CreateAudioSource failed");
-            TeardownLoopback();
-            return;
-        }
-        scoped_refptr<libwebrtc::RTCAudioTrack> audio_track =
-            factory_->CreateAudioTrack(audio_source, "loopback-track-0");
-        if (!audio_track) {
-            status_->SetLabel("CreateAudioTrack failed");
-            TeardownLoopback();
-            return;
-        }
+    // Synthetic video track: a custom (no-device) capturer is created and
+    // the source is fed by a producer thread that emits a 640x480 frame
+    // cycling through red / green / blue / white / black, one full-screen
+    // colour per second.
 
-        std::vector<string> stream_ids;
-        stream_ids.push_back(string("loopback-stream"));
-        offerer_.pc->AddTrack(audio_track, stream_ids);
+    scoped_refptr<libwebrtc::RTCMediaConstraints> video_constraints =
+        libwebrtc::RTCMediaConstraints::Create();
+    video_source_ =
+        factory_->CreateCustomVideoSource("synthetic-video", video_constraints);
+    if (video_source_) {
+      local_video_track_ =
+          factory_->CreateVideoTrack(video_source_, "synthetic-video-0");
+    }
+    if (local_video_track_) {
+      offerer_.pc->AddTrack(local_video_track_, stream_ids);
+      Log("Pushing 640x480 synthetic frames at 30 fps");
+      pusher_running_.store(true);
+      scoped_refptr<libwebrtc::RTCVideoSource> src = video_source_;
+      pusher_thread_ = std::thread([this, src] { PushSyntheticFrames(src); });
+    } else {
+      Log("CreateVideoTrack failed; continuing audio-only");
+    }
 
-        // Synthetic video track: a custom (no-device) capturer is created and
-        // the source is fed by a producer thread that emits a 640x480 frame
-        // cycling through red / green / blue / white / black, one full-screen
-        // colour per second.
+    scoped_refptr<libwebrtc::RTCMediaConstraints> sdp_constraints =
+        libwebrtc::RTCMediaConstraints::Create();
 
-        scoped_refptr<libwebrtc::RTCMediaConstraints> video_constraints =
-            libwebrtc::RTCMediaConstraints::Create();
-        video_source_ = factory_->CreateCustomVideoSource("synthetic-video",
-                                                          video_constraints);
-        if (video_source_) {
-          local_video_track_ =
-              factory_->CreateVideoTrack(video_source_, "synthetic-video-0");
-        }
-        if (local_video_track_) {
-          offerer_.pc->AddTrack(local_video_track_, stream_ids);
-          Log("Pushing 640x480 synthetic frames at 30 fps");
-          pusher_running_.store(true);
-          scoped_refptr<libwebrtc::RTCVideoSource> src = video_source_;
-          pusher_thread_ =
-              std::thread([this, src] { PushSyntheticFrames(src); });
-        } else {
-          Log("CreateVideoTrack failed; continuing audio-only");
-        }
-
-        scoped_refptr<libwebrtc::RTCMediaConstraints> sdp_constraints =
-            libwebrtc::RTCMediaConstraints::Create();
-
-        // Kick off the negotiation: offerer creates the offer, the success
-        // callback feeds it into both sides and asks the answerer for an
-        // answer, which in turn is fed back into both sides.
-        offerer_.pc->CreateOffer(
-            [this, sdp_constraints](const string sdp, const string type) {
-                Log("[offerer] CreateOffer ok, len=%zu",
+    // Kick off the negotiation: offerer creates the offer, the success
+    // callback feeds it into both sides and asks the answerer for an
+    // answer, which in turn is fed back into both sides.
+    offerer_.pc->CreateOffer(
+        [this, sdp_constraints](const string sdp, const string type) {
+          Log("[offerer] CreateOffer ok, len=%zu", std::strlen(sdp.c_string()));
+          offerer_.pc->SetLocalDescription(
+              sdp, type, []() {}, OnSetSdpFailureForTag("offerer"));
+          answerer_.pc->SetRemoteDescription(
+              sdp, type, []() {}, OnSetSdpFailureForTag("answerer"));
+          answerer_.pc->CreateAnswer(
+              [this](const string sdp, const string type) {
+                Log("[answerer] CreateAnswer ok, len=%zu",
                     std::strlen(sdp.c_string()));
-                offerer_.pc->SetLocalDescription(
-                    sdp, type, []() {}, OnSetSdpFailureForTag("offerer"));
-                answerer_.pc->SetRemoteDescription(
+                answerer_.pc->SetLocalDescription(
                     sdp, type, []() {}, OnSetSdpFailureForTag("answerer"));
-                answerer_.pc->CreateAnswer(
-                    [this](const string sdp, const string type) {
-                        Log("[answerer] CreateAnswer ok, len=%zu",
-                            std::strlen(sdp.c_string()));
-                        answerer_.pc->SetLocalDescription(
-                            sdp, type, []() {},
-                            OnSetSdpFailureForTag("answerer"));
-                        offerer_.pc->SetRemoteDescription(
-                            sdp, type, []() {},
-                            OnSetSdpFailureForTag("offerer"));
-                    },
-                    OnSdpCreateFailureForTag("answerer"), sdp_constraints);
-            },
-            OnSdpCreateFailureForTag("offerer"), sdp_constraints);
+                offerer_.pc->SetRemoteDescription(
+                    sdp, type, []() {}, OnSetSdpFailureForTag("offerer"));
+              },
+              OnSdpCreateFailureForTag("answerer"), sdp_constraints);
+        },
+        OnSdpCreateFailureForTag("offerer"), sdp_constraints);
 
-        running_ = true;
-        start_btn_->Disable();
-        stop_btn_->Enable();
-        status_->SetLabel("Loopback running. See log below.");
+    running_ = true;
+    start_btn_->Disable();
+    stop_btn_->Enable();
+    status_->SetLabel("Loopback running. See log below.");
+  }
+
+  void OnStop(wxCommandEvent&) {
+    TeardownLoopback();
+    status_->SetLabel("Stopped.");
+    start_btn_->Enable();
+    stop_btn_->Disable();
+  }
+
+  void OnClose(wxCloseEvent& event) {
+    TeardownLoopback();
+    event.Skip();
+  }
+
+  void TeardownLoopback() {
+    offerer_.closed.store(true);
+    answerer_.closed.store(true);
+
+    // Stop the synthetic frame producer before anything else so a frame
+    // that's mid-OnCapturedFrame finishes against still-live state.
+    if (pusher_running_.exchange(false)) {
+      if (pusher_thread_.joinable()) pusher_thread_.join();
     }
 
-    void OnStop(wxCommandEvent&) {
-        TeardownLoopback();
-        status_->SetLabel("Stopped.");
-        start_btn_->Enable();
-        stop_btn_->Disable();
+    // Detach renderers so we drop the dangling pointer before the unique_ptr
+    // resets.
+    for (PeerSlot* slot : {&offerer_, &answerer_}) {
+      if (slot->remote_video_track && slot->remote_video_renderer) {
+        slot->remote_video_track->RemoveRenderer(
+            slot->remote_video_renderer.get());
+      }
+      slot->remote_video_track = nullptr;
+      slot->remote_video_renderer.reset();
     }
 
-    void OnClose(wxCloseEvent& event) {
-        TeardownLoopback();
-        event.Skip();
+    local_video_track_ = nullptr;
+    video_source_ = nullptr;
+
+    if (offerer_.pc) {
+      offerer_.pc->Close();
+      if (factory_) factory_->Delete(offerer_.pc);
+      offerer_.pc = nullptr;
     }
-
-    void TeardownLoopback() {
-        offerer_.closed.store(true);
-        answerer_.closed.store(true);
-
-        // Stop the synthetic frame producer before anything else so a frame
-        // that's mid-OnCapturedFrame finishes against still-live state.
-        if (pusher_running_.exchange(false)) {
-            if (pusher_thread_.joinable()) pusher_thread_.join();
-        }
-
-        // Detach renderers so we drop the dangling pointer before the unique_ptr
-        // resets.
-        for (PeerSlot* slot : {&offerer_, &answerer_}) {
-            if (slot->remote_video_track && slot->remote_video_renderer) {
-                slot->remote_video_track->RemoveRenderer(
-                    slot->remote_video_renderer.get());
-            }
-            slot->remote_video_track = nullptr;
-            slot->remote_video_renderer.reset();
-        }
-
-        local_video_track_ = nullptr;
-        video_source_ = nullptr;
-
-        if (offerer_.pc) {
-            offerer_.pc->Close();
-            if (factory_) factory_->Delete(offerer_.pc);
-            offerer_.pc = nullptr;
-        }
-        if (answerer_.pc) {
-            answerer_.pc->Close();
-            if (factory_) factory_->Delete(answerer_.pc);
-            answerer_.pc = nullptr;
-        }
-        offerer_.observer.reset();
-        answerer_.observer.reset();
-
-        if (factory_) {
-            factory_->Terminate();
-            factory_ = nullptr;
-            libwebrtc::LibWebRTC::Terminate();
-        }
-        running_ = false;
+    if (answerer_.pc) {
+      answerer_.pc->Close();
+      if (factory_) factory_->Delete(answerer_.pc);
+      answerer_.pc = nullptr;
     }
+    offerer_.observer.reset();
+    answerer_.observer.reset();
 
-    static libwebrtc::OnSdpCreateFailure OnSdpCreateFailureForTag(
-        const char* tag) {
-        return [tag](const char* error) {
-            Log("[%s] SDP create failure: %s", tag, error ? error : "(null)");
-        };
+    if (factory_) {
+      factory_->Terminate();
+      factory_ = nullptr;
+      libwebrtc::LibWebRTC::Terminate();
     }
+    running_ = false;
+  }
 
-    static libwebrtc::OnSetSdpFailure OnSetSdpFailureForTag(const char* tag) {
-        return [tag](const char* error) {
-            Log("[%s] SetDescription failure: %s", tag,
-                error ? error : "(null)");
-        };
+  static libwebrtc::OnSdpCreateFailure OnSdpCreateFailureForTag(
+      const char* tag) {
+    return [tag](const char* error) {
+      Log("[%s] SDP create failure: %s", tag, error ? error : "(null)");
+    };
+  }
+
+  static libwebrtc::OnSetSdpFailure OnSetSdpFailureForTag(const char* tag) {
+    return [tag](const char* error) {
+      Log("[%s] SetDescription failure: %s", tag, error ? error : "(null)");
+    };
+  }
+
+  wxButton* start_btn_;
+  wxButton* stop_btn_;
+  wxStaticText* status_;
+  wxTextCtrl* log_;
+  VideoRenderPanel* video_panel_ = nullptr;
+
+  // Generates a 640x480 I420 frame containing 8 vertical SMPTE-style colour
+  // bars that scroll horizontally a few pixels per frame, and pushes it
+  // through RTCVideoSource::OnCapturedFrame at ~30 fps. Holds a strong ref
+  // to the source so the source can't be destroyed mid-call.
+  void PushSyntheticFrames(scoped_refptr<libwebrtc::RTCVideoSource> source) {
+    constexpr int kWidth = 640;
+    constexpr int kHeight = 480;
+    constexpr int kYSize = kWidth * kHeight;
+    constexpr int kUVStride = kWidth / 2;
+    constexpr int kUVHeight = kHeight / 2;
+    constexpr int kUVSize = kUVStride * kUVHeight;
+    constexpr int kFrameBytes = kYSize + 2 * kUVSize;  // I420 packed
+    constexpr int kFps = 30;
+    constexpr auto kFrameInterval = std::chrono::microseconds(1'000'000 / kFps);
+
+    constexpr int kBars = 8;
+    constexpr int kBarWidth = kWidth / kBars;  // 80 px
+    constexpr int kScrollPxPerFrame = 4;       // ~ 120 px/sec
+
+    // BT.601 limited-range YUV for the eight reference colour bars,
+    // ordered the way SMPTE 75 % bars are typically drawn left to right.
+    struct YUV {
+      uint8_t y, u, v;
+    };
+    constexpr YUV palette[kBars] = {
+        {235, 128, 128},  // white
+        {210, 16, 146},   // yellow
+        {170, 166, 16},   // cyan
+        {145, 54, 34},    // green
+        {106, 202, 222},  // magenta
+        {81, 90, 240},    // red
+        {41, 240, 110},   // blue
+        {16, 128, 128},   // black
+    };
+
+    std::vector<uint8_t> buffer(kFrameBytes);
+    uint8_t* y_plane = buffer.data();
+    uint8_t* u_plane = y_plane + kYSize;
+    uint8_t* v_plane = u_plane + kUVSize;
+
+    // The bar pattern is constant per row, so we build one row of Y, U,
+    // V samples and memcpy it to every scanline. Far cheaper than a 2D
+    // nested loop, and keeps the cost trivial at 640x480 / 30fps.
+    std::vector<uint8_t> y_row(kWidth);
+    std::vector<uint8_t> u_row(kUVStride);
+    std::vector<uint8_t> v_row(kUVStride);
+
+    int frame_idx = 0;
+    auto next_tick = std::chrono::steady_clock::now();
+
+    while (pusher_running_.load()) {
+      int scroll = (frame_idx * kScrollPxPerFrame) % kWidth;
+
+      // Build one Y row: each column picks its bar from the scrolled
+      // pattern.
+      for (int x = 0; x < kWidth; ++x) {
+        int bar = ((x + scroll) % kWidth) / kBarWidth;
+        y_row[x] = palette[bar].y;
+      }
+      // Build one U/V row at half horizontal resolution. Sample at
+      // x*2 to match the I420 chroma siting.
+      for (int x = 0; x < kUVStride; ++x) {
+        int bar = ((x * 2 + scroll) % kWidth) / kBarWidth;
+        u_row[x] = palette[bar].u;
+        v_row[x] = palette[bar].v;
+      }
+      // Replicate rows down each plane.
+      for (int y = 0; y < kHeight; ++y) {
+        std::memcpy(y_plane + y * kWidth, y_row.data(), kWidth);
+      }
+      for (int y = 0; y < kUVHeight; ++y) {
+        std::memcpy(u_plane + y * kUVStride, u_row.data(), kUVStride);
+        std::memcpy(v_plane + y * kUVStride, v_row.data(), kUVStride);
+      }
+
+      scoped_refptr<libwebrtc::RTCVideoFrame> frame =
+          libwebrtc::RTCVideoFrame::Create(kWidth, kHeight, buffer.data(),
+                                           kFrameBytes);
+      if (frame) source->OnCapturedFrame(frame);
+
+      if (frame_idx % (kFps * 2) == 0) {
+        Log("[pusher] color bars frame #%d (scroll=%d)", frame_idx, scroll);
+      }
+      ++frame_idx;
+      next_tick += kFrameInterval;
+      std::this_thread::sleep_until(next_tick);
     }
+  }
 
-    wxButton* start_btn_;
-    wxButton* stop_btn_;
-    wxStaticText* status_;
-    wxTextCtrl* log_;
-    VideoRenderPanel* video_panel_ = nullptr;
+  scoped_refptr<libwebrtc::RTCPeerConnectionFactory> factory_;
+  PeerSlot offerer_;
+  PeerSlot answerer_;
 
-    // Generates a 640x480 I420 frame containing 8 vertical SMPTE-style colour
-    // bars that scroll horizontally a few pixels per frame, and pushes it
-    // through RTCVideoSource::OnCapturedFrame at ~30 fps. Holds a strong ref
-    // to the source so the source can't be destroyed mid-call.
-    void PushSyntheticFrames(scoped_refptr<libwebrtc::RTCVideoSource> source) {
-        constexpr int kWidth = 640;
-        constexpr int kHeight = 480;
-        constexpr int kYSize = kWidth * kHeight;
-        constexpr int kUVStride = kWidth / 2;
-        constexpr int kUVHeight = kHeight / 2;
-        constexpr int kUVSize = kUVStride * kUVHeight;
-        constexpr int kFrameBytes = kYSize + 2 * kUVSize;  // I420 packed
-        constexpr int kFps = 30;
-        constexpr auto kFrameInterval =
-            std::chrono::microseconds(1'000'000 / kFps);
+  scoped_refptr<libwebrtc::RTCVideoSource> video_source_;
+  scoped_refptr<libwebrtc::RTCVideoTrack> local_video_track_;
 
-        constexpr int kBars = 8;
-        constexpr int kBarWidth = kWidth / kBars;          // 80 px
-        constexpr int kScrollPxPerFrame = 4;               // ~ 120 px/sec
+  std::thread pusher_thread_;
+  std::atomic<bool> pusher_running_{false};
 
-        // BT.601 limited-range YUV for the eight reference colour bars,
-        // ordered the way SMPTE 75 % bars are typically drawn left to right.
-        struct YUV { uint8_t y, u, v; };
-        constexpr YUV palette[kBars] = {
-            {235, 128, 128}, // white
-            {210,  16, 146}, // yellow
-            {170, 166,  16}, // cyan
-            {145,  54,  34}, // green
-            {106, 202, 222}, // magenta
-            { 81,  90, 240}, // red
-            { 41, 240, 110}, // blue
-            { 16, 128, 128}, // black
-        };
-
-        std::vector<uint8_t> buffer(kFrameBytes);
-        uint8_t* y_plane = buffer.data();
-        uint8_t* u_plane = y_plane + kYSize;
-        uint8_t* v_plane = u_plane + kUVSize;
-
-        // The bar pattern is constant per row, so we build one row of Y, U,
-        // V samples and memcpy it to every scanline. Far cheaper than a 2D
-        // nested loop, and keeps the cost trivial at 640x480 / 30fps.
-        std::vector<uint8_t> y_row(kWidth);
-        std::vector<uint8_t> u_row(kUVStride);
-        std::vector<uint8_t> v_row(kUVStride);
-
-        int frame_idx = 0;
-        auto next_tick = std::chrono::steady_clock::now();
-
-        while (pusher_running_.load()) {
-            int scroll = (frame_idx * kScrollPxPerFrame) % kWidth;
-
-            // Build one Y row: each column picks its bar from the scrolled
-            // pattern.
-            for (int x = 0; x < kWidth; ++x) {
-                int bar = ((x + scroll) % kWidth) / kBarWidth;
-                y_row[x] = palette[bar].y;
-            }
-            // Build one U/V row at half horizontal resolution. Sample at
-            // x*2 to match the I420 chroma siting.
-            for (int x = 0; x < kUVStride; ++x) {
-                int bar = ((x * 2 + scroll) % kWidth) / kBarWidth;
-                u_row[x] = palette[bar].u;
-                v_row[x] = palette[bar].v;
-            }
-            // Replicate rows down each plane.
-            for (int y = 0; y < kHeight; ++y) {
-                std::memcpy(y_plane + y * kWidth, y_row.data(), kWidth);
-            }
-            for (int y = 0; y < kUVHeight; ++y) {
-                std::memcpy(u_plane + y * kUVStride, u_row.data(), kUVStride);
-                std::memcpy(v_plane + y * kUVStride, v_row.data(), kUVStride);
-            }
-
-            scoped_refptr<libwebrtc::RTCVideoFrame> frame =
-                libwebrtc::RTCVideoFrame::Create(kWidth, kHeight,
-                                                 buffer.data(), kFrameBytes);
-            if (frame) source->OnCapturedFrame(frame);
-
-            if (frame_idx % (kFps * 2) == 0) {
-                Log("[pusher] color bars frame #%d (scroll=%d)",
-                    frame_idx, scroll);
-            }
-            ++frame_idx;
-            next_tick += kFrameInterval;
-            std::this_thread::sleep_until(next_tick);
-        }
-    }
-
-    scoped_refptr<libwebrtc::RTCPeerConnectionFactory> factory_;
-    PeerSlot offerer_;
-    PeerSlot answerer_;
-
-    scoped_refptr<libwebrtc::RTCVideoSource>   video_source_;
-    scoped_refptr<libwebrtc::RTCVideoTrack>    local_video_track_;
-
-    std::thread pusher_thread_;
-    std::atomic<bool> pusher_running_{false};
-
-    bool running_ = false;
+  bool running_ = false;
 };
 
 class LoopbackApp : public wxApp {
-public:
-    bool OnInit() override {
-        auto* frame = new MainFrame();
-        frame->Show();
-        return true;
-    }
+ public:
+  bool OnInit() override {
+    auto* frame = new MainFrame();
+    frame->Show();
+    return true;
+  }
 };
 
 wxIMPLEMENT_APP(LoopbackApp);

--- a/include/rtc_peerconnection_factory.h
+++ b/include/rtc_peerconnection_factory.h
@@ -49,6 +49,10 @@ class RTCPeerConnectionFactory : public RefCountInterface {
   virtual scoped_refptr<RTCVideoSource> CreateVideoSource(
       scoped_refptr<RTCVideoCapturer> capturer, const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) = 0;
+
+  virtual scoped_refptr<RTCVideoSource> CreateCustomVideoSource(string video_source_label,
+      scoped_refptr<RTCMediaConstraints> constraints) = 0;
+
 #ifdef RTC_DESKTOP_DEVICE
   virtual scoped_refptr<RTCVideoSource> CreateDesktopSource(
       scoped_refptr<RTCDesktopCapturer> capturer,

--- a/include/rtc_video_source.h
+++ b/include/rtc_video_source.h
@@ -2,11 +2,26 @@
 #define LIB_WEBRTC_RTC_VIDEO_SOURCE_HXX
 
 #include "rtc_types.h"
+#include "rtc_video_frame.h"
 
 namespace libwebrtc {
 
 class RTCVideoSource : public RefCountInterface {
  public:
+  enum class SourceType { kPlatformDevice, kCustom };
+
+  // Push a user-supplied frame into the source, bypassing any underlying
+  // capture device. The frame travels through the same adaptation and
+  // broadcast pipeline that camera/desktop sources use, so it is delivered to
+  // every sink (RTP encoder, local renderer, etc.) that has subscribed to
+  // this source.
+  //
+  // Sources that are not backed by an injectable capturer (e.g. the desktop
+  // capture path on some platforms) should treat this as a no-op.
+  virtual void OnCapturedFrame(scoped_refptr<RTCVideoFrame> frame)  = 0;
+
+  virtual SourceType GetSourceType() const = 0;
+
   ~RTCVideoSource() {}
 };
 }  // namespace libwebrtc

--- a/src/internal/video_capturer.h
+++ b/src/internal/video_capturer.h
@@ -40,8 +40,12 @@ class VideoCapturer : public webrtc::VideoSourceInterface<VideoFrame> {
                        const webrtc::VideoSinkWants& wants) override;
   void RemoveSink(webrtc::VideoSinkInterface<VideoFrame>* sink) override;
 
- protected:
+  // Pushes a captured frame through the adaptation/broadcast pipeline.
+  // Made public so RTCVideoSourceImpl can forward user-supplied frames into
+  // the same path that camera/desktop subclasses feed.
   void OnFrame(const VideoFrame& frame);
+
+ protected:
   webrtc::VideoSinkWants GetSinkWants();
 
  private:

--- a/src/rtc_peerconnection_factory_impl.cc
+++ b/src/rtc_peerconnection_factory_impl.cc
@@ -255,13 +255,32 @@ scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateVideoSource_s(
       static_cast<RTCVideoCapturerImpl*>(capturer.get());
   /*RTCMediaConstraintsImpl* media_constraints =
           static_cast<RTCMediaConstraintsImpl*>(constraints.get());*/
+  std::shared_ptr<webrtc::internal::VideoCapturer> internal_capturer =
+      capturer_impl->video_capturer();
   webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> rtc_source_track =
       webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface>(
           new webrtc::RefCountedObject<webrtc::internal::CapturerTrackSource>(
-              capturer_impl->video_capturer()));
+              internal_capturer));
+  // Pass the internal capturer through so RTCVideoSource::OnCapturedFrame can
+  // forward user-supplied frames into the same broadcast pipeline.
   scoped_refptr<RTCVideoSourceImpl> source = scoped_refptr<RTCVideoSourceImpl>(
-      new RefCountedObject<RTCVideoSourceImpl>(rtc_source_track));
+      new RefCountedObject<RTCVideoSourceImpl>(rtc_source_track,
+                                               internal_capturer));
   return source;
+}
+
+scoped_refptr<RTCVideoSource> RTCPeerConnectionFactoryImpl::CreateCustomVideoSource(
+  string video_source_label,
+  scoped_refptr<RTCMediaConstraints> constraints) {
+  // A vanilla internal::VideoCapturer is a complete passthrough: its default
+  // StartCapture/StopCapture/CaptureStarted are no-ops, but OnFrame still
+  // routes pushed frames through the video adapter and broadcaster, which is
+  // all OnCapturedFrame needs.
+  std::shared_ptr<webrtc::internal::VideoCapturer> internal_capturer =
+      std::make_shared<webrtc::internal::VideoCapturer>();
+  auto capture = scoped_refptr<RTCVideoCapturerImpl>(
+      new RefCountedObject<RTCVideoCapturerImpl>(internal_capturer));
+  return CreateVideoSource(capture, video_source_label, constraints);
 }
 
 #ifdef RTC_DESKTOP_DEVICE

--- a/src/rtc_peerconnection_factory_impl.h
+++ b/src/rtc_peerconnection_factory_impl.h
@@ -54,6 +54,10 @@ class RTCPeerConnectionFactoryImpl : public RTCPeerConnectionFactory {
   virtual scoped_refptr<RTCVideoSource> CreateVideoSource(
       scoped_refptr<RTCVideoCapturer> capturer, const string video_source_label,
       scoped_refptr<RTCMediaConstraints> constraints) override;
+
+  virtual scoped_refptr<RTCVideoSource> CreateCustomVideoSource(string video_source_label,
+      scoped_refptr<RTCMediaConstraints> constraints) override;
+
 #ifdef RTC_DESKTOP_DEVICE
   virtual scoped_refptr<RTCDesktopDevice> GetDesktopDevice() override;
   virtual scoped_refptr<RTCVideoSource> CreateDesktopSource(

--- a/src/rtc_video_frame_impl.h
+++ b/src/rtc_video_frame_impl.h
@@ -47,7 +47,7 @@ class VideoFrameBufferImpl : public RTCVideoFrame {
 
   virtual RTCVideoFrame::VideoRotation rotation() override;
 
-  webrtc::VideoRotation rotation() const { return rotation_; }
+  webrtc::VideoRotation rtc_rotation() const { return rotation_; }
 
   void set_rotation(webrtc::VideoRotation rotation) { rotation_ = rotation; }
 

--- a/src/rtc_video_source_impl.cc
+++ b/src/rtc_video_source_impl.cc
@@ -1,7 +1,9 @@
 #include "rtc_video_source_impl.h"
 
+#include "api/video/video_frame.h"
 #include "modules/video_capture/video_capture_factory.h"
 #include "rtc_base/logging.h"
+#include "rtc_base/time_utils.h"
 #include "rtc_video_frame_impl.h"
 
 namespace libwebrtc {
@@ -12,8 +14,38 @@ RTCVideoSourceImpl::RTCVideoSourceImpl(
   RTC_LOG(LS_INFO) << __FUNCTION__ << ": ctor ";
 }
 
+RTCVideoSourceImpl::RTCVideoSourceImpl(
+    webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> rtc_source_track,
+    std::shared_ptr<webrtc::internal::VideoCapturer> capturer)
+    : rtc_source_track_(rtc_source_track), capturer_(std::move(capturer)) {
+  type_ = SourceType::kCustom;
+  RTC_LOG(LS_INFO) << __FUNCTION__ << ": ctor (with capturer)";
+}
+
 RTCVideoSourceImpl::~RTCVideoSourceImpl() {
   RTC_LOG(LS_INFO) << __FUNCTION__ << ": dtor ";
+}
+
+void RTCVideoSourceImpl::OnCapturedFrame(scoped_refptr<RTCVideoFrame> frame) {
+  if (!frame || !capturer_) {
+    return;
+  }
+
+  // The public RTCVideoFrame is always backed by VideoFrameBufferImpl, so we
+  // can recover the native buffer/rotation/timestamp without copying.
+  VideoFrameBufferImpl* impl = static_cast<VideoFrameBufferImpl*>(frame.get());
+
+  int64_t timestamp_us = impl->timestamp_us();
+  if (timestamp_us == 0) {
+    timestamp_us = webrtc::TimeMicros();
+  }
+
+  webrtc::VideoFrame video_frame = webrtc::VideoFrame::Builder()
+                                       .set_video_frame_buffer(impl->buffer())
+                                       .set_rotation(impl->rtc_rotation())
+                                       .set_timestamp_us(timestamp_us)
+                                       .build();
+  capturer_->OnFrame(video_frame);
 }
 
 }  // namespace libwebrtc

--- a/src/rtc_video_source_impl.h
+++ b/src/rtc_video_source_impl.h
@@ -1,6 +1,8 @@
 #ifndef LIB_WEBRTC_VIDEO_SOURCE_IMPL_HXX
 #define LIB_WEBRTC_VIDEO_SOURCE_IMPL_HXX
 
+#include <memory>
+
 #include "api/media_stream_interface.h"
 #include "media/base/video_broadcaster.h"
 #include "media/base/video_source_base.h"
@@ -8,13 +10,25 @@
 #include "rtc_video_frame.h"
 #include "rtc_video_source.h"
 #include "rtc_video_track.h"
+#include "src/internal/video_capturer.h"
 
 namespace libwebrtc {
 
 class RTCVideoSourceImpl : public RTCVideoSource {
  public:
+  // For sources that wrap a VideoTrackSourceInterface only (e.g. desktop
+  // sources). OnCapturedFrame is a no-op for instances created via this
+  // constructor since there is no internal capturer to push into.
   RTCVideoSourceImpl(
       webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> video_source_track);
+
+  // For sources backed by a libwebrtc internal::VideoCapturer (the regular
+  // CapturerTrackSource path). OnCapturedFrame forwards user-supplied frames
+  // through the capturer's broadcast pipeline.
+  RTCVideoSourceImpl(
+      webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> video_source_track,
+      std::shared_ptr<webrtc::internal::VideoCapturer> capturer);
+
   virtual ~RTCVideoSourceImpl();
 
   virtual webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface>
@@ -22,8 +36,16 @@ class RTCVideoSourceImpl : public RTCVideoSource {
     return rtc_source_track_;
   }
 
+  void OnCapturedFrame(scoped_refptr<RTCVideoFrame> frame) override;
+
+  SourceType GetSourceType() const override {
+    return type_;
+  }
+
  private:
   webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> rtc_source_track_;
+  std::shared_ptr<webrtc::internal::VideoCapturer> capturer_;
+  SourceType type_ = SourceType::kPlatformDevice;
 };
 }  // namespace libwebrtc
 


### PR DESCRIPTION
# feat: custom video source via `RTCVideoSource::OnCapturedFrame`

Let's applications inject their own video frames into the libwebrtc pipeline
without going through a camera or desktop capturer. Adds a wxWidgets demo
that uses the new API to stream synthetic SMPTE colour bars between two
in-process peer connections.

## Public API additions

- **`RTCVideoSource::OnCapturedFrame(scoped_refptr<RTCVideoFrame>)`**
- **`RTCVideoSource::GetSourceType()`**
- **`RTCPeerConnectionFactory::CreateCustomVideoSource(string video_source_label,
      scoped_refptr<RTCMediaConstraints> constraints)`**

## Implementation notes

- `internal::VideoCapturer::OnFrame` promoted from `protected` to `public`
  so `RTCVideoSourceImpl` can forward user frames into the broadcaster
  without a friend declaration.
- `RTCVideoSourceImpl` gains a second constructor that stores a
  `shared_ptr<internal::VideoCapturer>`; the desktop-source path keeps the
  old single-arg ctor and treats `OnCapturedFrame` as a no-op.
- `RTCVideoFrame::timestamp_us == 0` falls back to `webrtc::TimeMicros()` so
  callers can omit the timestamp.

## Demo: `examples/wx_loop_back_demo`

- wxWidgets app (CMake + `find_package(wxWidgets)`).
- Two in-process `RTCPeerConnection`s, full offer/answer + ICE exchange,
  one audio track and one synthetic video track.
- Frame producer pushes 640×480 I420 SMPTE colour bars scrolling at
  ~120 px/sec via `OnCapturedFrame`.
- Decoded remote video rendered into a `wxPanel` (I420 → ABGR via
  libyuv → `wxImage` → `wxBitmap`).
- macOS bundling: post-build copies `libwebrtc.dylib` into
  `Contents/Frameworks/`, rewrites the executable's recorded dependency to
  `@rpath/libwebrtc.dylib`, ad-hoc re-signs both binaries.
- README with build, run, and verification steps.


<img width="640" alt="image" src="https://github.com/user-attachments/assets/1922d811-fa30-4ee2-9426-c90558067872" />