### PR TITLE
Windows: allow 176.4/192 kHz shared-mode device formats in legacy ADM

### DIFF
--- a/build/libwebrtc_win_build.cmd
+++ b/build/libwebrtc_win_build.cmd
@@ -93,6 +93,7 @@ cd src
 copy .vpython3 ..
 call git apply "libwebrtc\patches\custom_audio_source_m144.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 call git apply "libwebrtc\patches\add_libwebrtc_build_target.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
+call git apply "libwebrtc\patches\allow_176k4_192k_shared_mode_formats.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 cd ..
 
 if not exist "%ARTIFACTS_DIR%\lib" (

--- a/patches/allow_176k4_192k_shared_mode_formats.patch
+++ b/patches/allow_176k4_192k_shared_mode_formats.patch
@@ -1,0 +1,20 @@
+--- a/modules/audio_device/win/audio_device_core_win.cc
++++ b/modules/audio_device/win/audio_device_core_win.cc
+@@ -1867,7 +1867,7 @@
+   Wfx.wBitsPerSample = 16;
+   Wfx.cbSize = 0;
+ 
+-  const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000};
++  const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000, 176400, 192000};
+   hr = S_FALSE;
+ 
+   // Iterate over frequencies and channels, in order of priority
+@@ -2185,7 +2185,7 @@
+   Wfx.Samples.wValidBitsPerSample = Wfx.Format.wBitsPerSample;
+   Wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+ 
+-  const int freqs[6] = {48000, 44100, 16000, 96000, 32000, 8000};
++  const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000, 176400, 192000};
+   hr = S_FALSE;
+ 
+   // Iterate over frequencies and channels, in order of priority


### PR DESCRIPTION
**Problem**

On Windows, when the default playback (or capture) device's shared-mode default format is set to 176400 or 192000 Hz ("Studio quality" — increasingly common on consumer "Hi-Res" audio devices), `InitPlayout`/`InitRecording` in `modules/audio_device/win/audio_device_core_win.cc` fail: the hardcoded candidate list `{48000, 44100, 16000, 96000, 32000, 8000}` never matches the device mix format, and the legacy ADM does not use `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`. For a VoIP app the result is that the call connects (signaling is fine) but audio capture stops the moment playout tries to start — the mic is silently released.

**Reproduction / verification (real device, Windows 11 24H2)**

- Device format 192000 Hz, unpatched m144 build: call connects, `outbound-rtp packetsSent = 0`, `media-source audioLevel = 0.0` for the whole call while inbound keeps flowing. Setting the device to 96000 Hz (which is in the list) immediately fixes it.
- With this patch (m144_release + the added patch file, built via this repo's Actions workflow): same 192 kHz setup, capture stays alive and two-way audio works.

**Fix**

Adds `patches/allow_176k4_192k_shared_mode_formats.patch` (applied in `build/libwebrtc_win_build.cmd`, same mechanism as the existing engine patches): appends 176400 and 192000 to the candidate list in both `InitPlayout` and `InitRecording`. Appending at the end keeps the existing priority order, so behavior is unchanged for every device that works today; `AudioDeviceBuffer` sizes its buffers dynamically.

**Precedents**: Second Life patched their WebRTC fork the same way when moving to m137 (secondlife/viewer#4593); Microsoft hit the same root cause in MixedReality-WebRTC#370.
